### PR TITLE
1.3.6pre

### DIFF
--- a/lib/agent/plugins/control-panel/sender.js
+++ b/lib/agent/plugins/control-panel/sender.js
@@ -25,7 +25,7 @@ var make_request = function(what, data, opts, cb) {
     // if there was an error, lets try connecting via a proxy if possible
     if (err && !opts.proxy && (try_proxy || '').match('.')) {
       opts.proxy = try_proxy;
-      return make_request(what, data, opts, callback);
+      return make_request(what, data, opts, cb);
     }
 
     bus.emit('response', what, err, resp);
@@ -33,21 +33,17 @@ var make_request = function(what, data, opts, cb) {
   });
 };
 
-var send = function(what, data, opts, callback) {
+var send = function(what, data, opts, cb) {
   var opts = opts || {};
 
-  if (!send_status_info || what == 'response')
-    return make_request(what, data, opts, callback);
-
   var done = function(err, resp) {
-    if (err) {
-      var str = 'Got error: ' + err.message;
-    } else {
-      var str = 'Got status ' + resp.statusCode + ' from server: ' + resp.body.toString();
-    }
-
+    var str = err ? 'Got error: ' + err.message : 'Got ' + resp.statusCode + ' response: ' + resp.body.toString();
     logger.info(str);
+    cb && cb(err, resp);
   }
+
+  if (!send_status_info || what == 'response')
+    return make_request(what, data, opts, done);
 
   get_status_info(function(err, status) {
     opts.status = status;

--- a/lib/agent/triggers.js
+++ b/lib/agent/triggers.js
@@ -1,6 +1,7 @@
 var fs       = require('fs'),
     join     = require('path').join,
     actions  = require('./actions'),
+    hooks    = require('./hooks'),
     logger   = require('./common').logger.prefix('triggers');
 
 var watchers = [],

--- a/lib/conf/tasks/index.js
+++ b/lib/conf/tasks/index.js
@@ -41,35 +41,39 @@ var set_up_config = function(cb) {
   });
 }
 
-var chmod_version = function(version, cb) {
-  chmod(join(paths.versions, version), '0755', cb);
-};
-
 var set_up_version = function(version, cb) {
+
+  function finish() {
+    // first, ensure that /current path is readable by non-prey users
+    // so that impersonated commands within path work as expected.
+    log('Setting permissions...');
+    chmod(paths.current, '0755', function(err) {
+      if (err) return cb(err);
+
+      // call post_activation hooks (e.g. firewall toggling in Windows)
+      log('Running post_activate hooks...');
+      os_hooks.post_activate(cb);
+    });
+  }
+
   set_up_config(function(err) {
     if (err) return cb(err);
 
     if (!paths.versions) { // no version support, so cannot set version as current
       log('No versions support.');
-      return os_hooks.post_activate(cb);
+      finish();
     }
 
-    chmod_version(version, function(err) {
-      if (err) return cb(err);
+    log('Setting up ' + version + ' as current...');
+    shared.version_manager.set_current(version, function(err){
+      if (err) {
+        if (err.code == 'ALREADY_CURRENT')
+          log('Warning: This version is already set as current.');
+        else
+          return cb(err);
+      }
 
-      log('Setting up ' + version + ' as current...');
-      shared.version_manager.set_current(version, function(err){
-        if (err) {
-          if (err.code == 'ALREADY_CURRENT')
-            log('Warning: This version is already set as current.');
-          else
-            return cb(err);
-        }
-
-        log('Version set. Running post_activate hooks.');
-        // call post_activation hooks (e.g. firewall toggling in Windows)
-        os_hooks.post_activate(cb);
-      });
+      finish();
     });
 
   })

--- a/lib/conf/tasks/index.js
+++ b/lib/conf/tasks/index.js
@@ -5,7 +5,7 @@ var fs         = require('fs'),
     join       = require('path').join,
     paths      = common.system.paths,
     os_name    = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
-    chmod      = require('chela').chmod;
+    chmod      = require('chela').mod;
 
 /////////////////////////////////////////////////////////////////
 // local requires

--- a/lib/conf/tasks/index.js
+++ b/lib/conf/tasks/index.js
@@ -2,8 +2,10 @@ var fs         = require('fs'),
     async      = require('async'),
     shared     = require('./../shared'),
     common     = require('./../../common'),
+    join       = require('path').join,
     paths      = common.system.paths,
-    os_name    = process.platform.replace('win32', 'windows').replace('darwin', 'mac');
+    os_name    = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
+    chmod      = require('chela').chmod;
 
 /////////////////////////////////////////////////////////////////
 // local requires
@@ -39,6 +41,10 @@ var set_up_config = function(cb) {
   });
 }
 
+var chmod_version = function(version, cb) {
+  chmod(join(paths.versions, version), '0755', cb);
+};
+
 var set_up_version = function(version, cb) {
   set_up_config(function(err) {
     if (err) return cb(err);
@@ -48,19 +54,24 @@ var set_up_version = function(version, cb) {
       return os_hooks.post_activate(cb);
     }
 
-    log('Setting up ' + version + ' as current...');
-    shared.version_manager.set_current(version, function(err){
-      if (err) {
-        if (err.code == 'ALREADY_CURRENT')
-          log('Warning: This version is already set as current.');
-        else
-          return cb(err);
-      }
+    chmod_version(version, function(err) {
+      if (err) return cb(err);
 
-      log('Version set. Running post_activate hooks.');
-      // call post_activation hooks (e.g. firewall toggling in Windows)
-      os_hooks.post_activate(cb);
+      log('Setting up ' + version + ' as current...');
+      shared.version_manager.set_current(version, function(err){
+        if (err) {
+          if (err.code == 'ALREADY_CURRENT')
+            log('Warning: This version is already set as current.');
+          else
+            return cb(err);
+        }
+
+        log('Version set. Running post_activate hooks.');
+        // call post_activation hooks (e.g. firewall toggling in Windows)
+        os_hooks.post_activate(cb);
+      });
     });
+
   })
 }
 

--- a/lib/conf/tasks/index.js
+++ b/lib/conf/tasks/index.js
@@ -61,11 +61,11 @@ var set_up_version = function(version, cb) {
 
     if (!paths.versions) { // no version support, so cannot set version as current
       log('No versions support.');
-      finish();
+      return finish();
     }
 
     log('Setting up ' + version + ' as current...');
-    shared.version_manager.set_current(version, function(err){
+    shared.version_manager.set_current(version, function(err) {
       if (err) {
         if (err.code == 'ALREADY_CURRENT')
           log('Warning: This version is already set as current.');

--- a/lib/conf/tasks/index.js
+++ b/lib/conf/tasks/index.js
@@ -5,7 +5,7 @@ var fs         = require('fs'),
     join       = require('path').join,
     paths      = common.system.paths,
     os_name    = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
-    chmod      = require('chela').mod;
+    chela      = require('chela');
 
 /////////////////////////////////////////////////////////////////
 // local requires
@@ -46,8 +46,8 @@ var set_up_version = function(version, cb) {
   function finish() {
     // first, ensure that /current path is readable by non-prey users
     // so that impersonated commands within path work as expected.
-    log('Setting permissions...');
-    chmod(paths.current, '0755', function(err) {
+    log('Setting permissions on ' + paths.current);
+    chela.mod(paths.current, '0755', function(err) {
       if (err) return cb(err);
 
       // call post_activation hooks (e.g. firewall toggling in Windows)

--- a/lib/conf/tasks/utils/create_user.sh
+++ b/lib/conf/tasks/utils/create_user.sh
@@ -60,7 +60,7 @@ create_user() {
     useradd -r -M -U -G ${ADMIN_GROUP} -s $SHELL $USER_NAME
 
     for group in $groups; do
-      adduser $USER_NAME $group 2> /dev/null || true
+      usermod -a -G $group $USER_NAME 2> /dev/null || true
     done
 
   else

--- a/lib/system/windows/index.js
+++ b/lib/system/windows/index.js
@@ -55,5 +55,5 @@ exports.get_os_name = function(callback) {
 
 exports.reconnect = function(cb) {
   var cmd_path = path.join(__dirname, 'bin', 'autowc.exe');
-  exec(cmd_path + ' -connect', cb);
+  exec('"' + cmd_path + '" -connect', cb);
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "prey",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "dependencies": {
     "async": {
       "version": "0.9.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -102,14 +102,14 @@
       "resolved": "git://github.com/tomas/node-campfire#c4b0517ce0e49000a14ba3cedcbd9b8df2d2f8d4"
     },
     "chela": {
-      "version": "0.0.3",
-      "from": "chela@0.0.3",
-      "resolved": "https://registry.npmjs.org/chela/-/chela-0.0.3.tgz",
+      "version": "0.0.5",
+      "from": "chela@0.0.5",
+      "resolved": "https://registry.npmjs.org/chela/-/chela-0.0.5.tgz",
       "dependencies": {
         "graceful-fs": {
-          "version": "3.0.4",
-          "from": "graceful-fs@3.0.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.4.tgz"
+          "version": "3.0.5",
+          "from": "graceful-fs@3.0.5",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "async": "",
     "buckle": "0.0.3",
     "campfire": "git://github.com/tomas/node-campfire",
-    "chela": "0.0.3",
+    "chela": "0.0.5",
     "clean-exit": "0.0.3",
     "colors": "^0.6.2",
     "commander": "",

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -26,7 +26,7 @@ cleanup() {
 run_specs(){
   echo "Ensuring we have the latest packages..."
   BUNDLE_ONLY=1 npm install
-  bin/prey test --recursive --bail --reporter dot
+  bin/prey test lib/agent/plugins --recursive --bail --reporter dot
 }
 
 create_release() {


### PR DESCRIPTION
# Changelog

- Fix: Make sure to chmod the current prey version directory on activation to 755, to ensure actions can be run and avoid other unexpected behaviours. Fix #61
- Fix: Add missing `hooks` require in `triggers.js`
- Fix: system.reconnect() for Windows to avoid errors when path has whitespaces.
- Fix: callback/cb function name in CP sender module.
- Fix: Added missing require in triggers.js.
- Update: Bump chela to 0.0.5