### PR TITLE
Windows AppData paths correction in wipe

### DIFF
--- a/lib/agent/actions/wipe/windows.js
+++ b/lib/agent/actions/wipe/windows.js
@@ -3,10 +3,10 @@ var os   = require('os'),
     exec = require('child_process').exec;
 
 if (parseFloat(os.release()) > 5.2) {
-  var data_path = 'Application Data';
+  var data_path = join('AppData', 'Local');
   var documents_path = ['Contacts', 'Documents', 'Downloads', 'Desktop', 'Pictures', 'Videos'];
 } else {
-  var data_path = join('AppData', 'Local');
+  var data_path = 'Application Data';
   var documents_path = ['Desktop', 'My Documents'];
 }
 


### PR DESCRIPTION
Windows Vista (>=6.0) introduced the AppData folder, while 2003 and below (<=5.2) used Application Data. Thus, it seems like these two lines should be swapped.