### PR TITLE
1.4.0-rc

### DIFF
--- a/lib/agent/helpers.js
+++ b/lib/agent/helpers.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var semver = require('semver');
+
 var helpers  = {};
 
 helpers.running_on_background = function() {
@@ -14,5 +16,11 @@ helpers.no_console_attached = function(){
 helpers.run_via_service = function(){
   return (process.platform == 'win32' && !process.env.HOMEPATH);
 }
+
+
+// is_greater_than("1.3.10", "1.3.9") returns true
+helpers.is_greater_than = function(first, second){
+  return semver.gt(first, second);
+};
 
 module.exports = helpers;

--- a/lib/package.js
+++ b/lib/package.js
@@ -1,22 +1,24 @@
-var fs         = require('fs'),
-    path       = require('path'),
-    needle     = require('needle'),
-    createHash = require('crypto').createHash,
-    rmdir      = require('rimraf'),
-    cp         = require('child_process'),
-    whenever   = require('whenever'),
-    os_name    = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
-    tmpdir     = os_name == 'windows' ? process.env.WINDIR + '\\Temp' : '/tmp';
+var fs              = require('fs'),
+    path            = require('path'),
+    needle          = require('needle'),
+    createHash      = require('crypto').createHash,
+    rmdir           = require('rimraf'),
+    cp              = require('child_process'),
+    whenever        = require('whenever'),
+    is_greater_than = require('./agent/helpers').is_greater_than,
 
-var delayed    = whenever('buckle');
+    os_name         = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
+    tmpdir          = os_name == 'windows' ? process.env.WINDIR + '\\Temp' : '/tmp';
 
-var npm_package_url  = 'https://registry.npmjs.org/prey';
+var delayed         = whenever('buckle');
 
-var releases_host    = 'https://s3.amazonaws.com',
-    releases_url     = releases_host + '/prey-releases/node-client/',
-    latest_text      = 'latest.txt',
-    checksums        = 'shasums.json',
-    package_format   = '.zip';
+var npm_package_url = 'https://registry.npmjs.org/prey';
+
+var releases_host   = 'https://s3.amazonaws.com',
+    releases_url    = releases_host + '/prey-releases/node-client/',
+    latest_text     = 'latest.txt',
+    checksums       = 'shasums.json',
+    package_format  = '.zip';
 
 /////////////////////////////////////////////////////////
 // helpers
@@ -24,13 +26,6 @@ var releases_host    = 'https://s3.amazonaws.com',
 var log = function(str) {
   if (process.stdout.writable)
     process.stdout.write(str + '\n');
-}
-
-// returns true if first is greater than second
-var is_greater_than = function(first, second){
-  var a = parseFloat(first.replace(/\./, ''));
-  var b = parseFloat(second.replace(/\./, ''));
-  return a > b ? true : false;
 };
 
 // returns sha1 checksum for file

--- a/lib/package.js
+++ b/lib/package.js
@@ -6,7 +6,6 @@ var fs              = require('fs'),
     cp              = require('child_process'),
     whenever        = require('whenever'),
     is_greater_than = require('./agent/helpers').is_greater_than,
-
     os_name         = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
     tmpdir          = os_name == 'windows' ? process.env.WINDIR + '\\Temp' : '/tmp';
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "prey",
-  "version": "1.3.10",
+  "version": "1.4.0",
   "dependencies": {
     "async": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prey",
-  "version": "1.3.10",
+  "version": "1.4.0",
   "author": "Tomás Pollak <tomas@forkhq.com>",
   "keywords": [
     "prey",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "rimraf": "",
     "satan": "^0.4.2",
     "scrambler": "0.0.1",
+    "semver": "^4.3.4",
     "serve-static": "^1.7.0",
     "sudoer": "^0.1.1",
     "triggers": "^0.3.0",

--- a/test/lib/agent/helpers.js
+++ b/test/lib/agent/helpers.js
@@ -1,0 +1,13 @@
+var test_helpers = require('../../helpers'),
+    helpers = require(test_helpers.lib_path('agent', 'helpers')),
+    should  = require('should');
+
+describe('helpers.is_greater_than', function() {
+  it('returns false when first is lower than second', function () {
+    helpers.is_greater_than("1.3.9", "1.3.10").should.equal(false);
+  });
+
+  it('returns true when first is higher than second', function() {
+    helpers.is_greater_than("1.3.10", "1.3.9").should.equal(true);
+  });
+});


### PR DESCRIPTION
This PR changes the way the client verifies if the latest version is higher than the current. Due to an error in the previous implementation, "1.3.10" was considered lower than "1.3.9", disabling the auto-update feature.

It also bumps the version to 1.4.0 to ensure the current 1.3.9 clients update, hence getting the fix mentioned above.

![ocss_2015-05-12_20 33 23](https://cloud.githubusercontent.com/assets/844344/7601261/44b4cb9e-f8ea-11e4-9595-cfd7c97f85f9.png)
