### PR TITLE
Update npm-shrinkwrap to include semver

### DIFF
--- a/lib/agent/helpers.js
+++ b/lib/agent/helpers.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var semver = require('semver');
+var semver      = require('semver'),
+    exceptions  = require('../exceptions');
 
 var helpers  = {};
 
@@ -20,11 +21,22 @@ helpers.run_via_service = function(){
 
 // is_greater_than("1.3.10", "1.3.9") returns true
 helpers.is_greater_than = function(first, second) {
+  var invalid = [];
+
   [first, second].forEach(function (el, i) {
+
     if(!semver.valid(el)) {
-      first = second = "0.0.1";
+
+      var label = i === 0 ? "latest" : "current";
+      invalid.push(label);
     }
+
   });
+
+  if (invalid.length > 0) {
+    first = second = "0.0.1";
+    exceptions.send(new Error("Cannot run is_greater_than: Invalid version"+ invalid));
+  }
 
   return semver.gt(first, second);
 };

--- a/lib/agent/helpers.js
+++ b/lib/agent/helpers.js
@@ -19,7 +19,13 @@ helpers.run_via_service = function(){
 
 
 // is_greater_than("1.3.10", "1.3.9") returns true
-helpers.is_greater_than = function(first, second){
+helpers.is_greater_than = function(first, second) {
+  [first, second].forEach(function (el, i) {
+    if(!semver.valid(el)) {
+      first = second = "0.0.1";
+    }
+  });
+
   return semver.gt(first, second);
 };
 

--- a/lib/agent/helpers.js
+++ b/lib/agent/helpers.js
@@ -27,7 +27,7 @@ helpers.is_greater_than = function(first, second) {
 
     if(!semver.valid(el)) {
 
-      var label = i === 0 ? "latest" : "current";
+      var label = i === 0 ? "first" : "second";
       invalid.push(label);
     }
 

--- a/lib/agent/helpers.js
+++ b/lib/agent/helpers.js
@@ -35,7 +35,7 @@ helpers.is_greater_than = function(first, second) {
 
   if (invalid.length > 0) {
     first = second = "0.0.1";
-    exceptions.send(new Error("Cannot run is_greater_than: Invalid version"+ invalid));
+    exceptions.send(new Error("Cannot run is_greater_than. Invalid versions: "+ invalid + ". Values: " + first + ", " + second));
   }
 
   return semver.gt(first, second);

--- a/lib/agent/plugins/control-panel/api/request.js
+++ b/lib/agent/plugins/control-panel/api/request.js
@@ -127,14 +127,12 @@ exports.use = function(obj) {
   for (var key in obj) {
     if (defaults.hasOwnProperty(key)) {
 
-      // logger.debug('Setting ' + key + ' to ' + obj[key]);
-
       if (key == 'protocol' && ['http', 'https'].indexOf(obj[key]) === -1) {
         logger.error('Invalid protocol: ' + obj[key]);
         continue;
       }
 
-      if (!obj[key]) {
+      if (key !== 'try_proxy' && !obj[key]) {
         logger.error('Empty API value for key: ' + key);
         continue;
       }

--- a/lib/agent/plugins/control-panel/interval/test/interval_spec.js
+++ b/lib/agent/plugins/control-panel/interval/test/interval_spec.js
@@ -52,6 +52,7 @@ describe('interval', function () {
   };
 
   before(function () {
+    api.use( { try_proxy: ''} );
     set_spies();
   });
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -685,6 +685,11 @@
       "from": "scrambler@0.0.1",
       "resolved": "https://registry.npmjs.org/scrambler/-/scrambler-0.0.1.tgz"
     },
+    "semver": {
+      "version": "4.3.4",
+      "from": "semver@*",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+    },
     "serve-static": {
       "version": "1.9.1",
       "from": "serve-static@1.9.1",
@@ -779,9 +784,9 @@
       "resolved": "https://registry.npmjs.org/sudoer/-/sudoer-0.1.1.tgz"
     },
     "triggers": {
-      "version": "0.2.0",
-      "from": "https://registry.npmjs.org/triggers/-/triggers-0.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/triggers/-/triggers-0.2.0.tgz"
+      "version": "0.3.0",
+      "from": "triggers@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/triggers/-/triggers-0.3.0.tgz"
     },
     "tuna": {
       "version": "0.0.2",

--- a/test/lib/agent/helpers.js
+++ b/test/lib/agent/helpers.js
@@ -10,4 +10,29 @@ describe('helpers.is_greater_than', function() {
   it('returns true when first is higher than second', function() {
     helpers.is_greater_than("1.3.10", "1.3.9").should.equal(true);
   });
+
+  it('returns false when both are equal', function() {
+    helpers.is_greater_than("1.3.10", "1.3.10").should.equal(false);
+  });
+
+  // In the following cases, there's no way to compare, hence it returns false
+
+  it('returns false when second is empty, null or undefined', function() {
+    helpers.is_greater_than("1.3.10", "").should.equal(false);
+    helpers.is_greater_than("1.3.10", null).should.equal(false);
+    helpers.is_greater_than("1.3.10", undefined).should.equal(false);
+  });
+
+  it('returns false when first is empty, null or undefined', function() {
+    helpers.is_greater_than("", "1.3.10").should.equal(false);
+    helpers.is_greater_than(null, "1.3.10").should.equal(false);
+    helpers.is_greater_than(undefined, "1.3.10").should.equal(false);
+  });
+
+  it('returns false if both are empty, null or undefined', function() {
+    helpers.is_greater_than("", "").should.equal(false);
+    helpers.is_greater_than(null, undefined).should.equal(false);
+    helpers.is_greater_than(undefined, null).should.equal(false);
+  });
+
 });

--- a/test/shrinkwrap_spec.js
+++ b/test/shrinkwrap_spec.js
@@ -1,0 +1,82 @@
+var fs                  = require('fs'),
+    join                = require('path').join,
+    should              = require('should'),
+    getset              = require('getset'),
+    is_windows          = process.platform === 'win32',
+    base_dir            = join(__dirname, '..'),
+    package_obj         = JSON.parse(fs.readFileSync(join(base_dir, 'package.json'), 'utf8')),
+    shrinkwrap          = JSON.parse(fs.readFileSync(join(base_dir, 'npm-shrinkwrap.json'), 'utf8'));
+
+function get_deps(obj) {
+  return JSON.stringify(Object.keys(obj.dependencies).sort());
+}
+
+var shrinkwrap_mock = {
+  dependencies: {
+    "package1": {
+      "version": "0.0.1",
+      "from": "https://someurl.com/package1-0.0.1.tgz",
+      "resolved": "https://someurl.com/package1-0.0.1.tgz"
+    },
+    "package2": {
+      "version": "0.0.2",
+      "from": "https://someurl.com/package2-0.0.2.tgz",
+      "resolved": "https://someurl.com/package2-0.0.2.tgz"
+    }
+  }
+};
+
+describe('npm-shrinkwrap and package.json', function () {
+
+  // testingception
+  describe('when different', function() {
+
+    var package_mock = {
+      dependencies: {
+        "package1": "0.0.1",
+        "package2": "0.0.2",
+        "package3": "0.0.3"
+      }
+    };
+
+    it('equals false', function() {
+
+      shrinkwrap_str = get_deps(shrinkwrap_mock);
+      package_str = get_deps(package_mock);
+
+      shrinkwrap_str.should.not.equal(package_str);
+    });
+  });
+
+  // testingception the sequel
+  describe('when equal', function() {
+
+    var package_mock = {
+      dependencies: {
+        "package1": "0.0.1",
+        "package2": "0.0.2",
+      }
+    };
+
+    it('equals true', function() {
+
+      shrinkwrap_str = get_deps(shrinkwrap_mock);
+      package_str = get_deps(package_mock);
+
+      shrinkwrap_str.should.equal(package_str);
+    });
+  });
+
+  describe('actual files', function() {
+
+    it('should have same dependencies', function() {
+
+      shrinkwrap_str = get_deps(shrinkwrap);
+      package_str = get_deps(package_obj);
+
+      shrinkwrap_str.should.equal(package_str);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This fixes a big issue I introduced in 1.4.0 that prevented said version from creating the `current` symlink and hence starting the client.

Pending: 
- [x] Specs for npm-shrinkwrap vs package.json
- [x] Additional specs for `is_greater_than`