### PR TITLE
Command persistence. fix #133, fix #127

### DIFF
--- a/lib/agent/commands.js
+++ b/lib/agent/commands.js
@@ -41,7 +41,7 @@ var handle_error = function(err) {
 }
 
 ////////////////////////////////////////////////////////////////////
-// build/parse/perform/process exports
+// build/run/parse/perform/process exports
 
 exports.build = function build(command, target, options) {
   var obj = { command: command, target: target };
@@ -103,6 +103,8 @@ exports.perform = function(command) {
   if (!command)
     return handle_error(new Error('No command received'));
 
+  logger.debug("Command received: " + JSON.stringify(command));
+
   var methods = {
     'start'   : actions.start,
     'stop'    : actions.stop,
@@ -112,6 +114,14 @@ exports.perform = function(command) {
     'report'  : reports.get,
     'cancel'  : reports.cancel,
     'upgrade' : updater.check
+  }
+
+  // Intercept {command: 'get', target: 'report', options: {interval: 5}}
+  // This kind of report should be storable. To ensure it can be stored we need
+  // to change it to {command: 'report', target: 'stolen'}
+  if (command.command === "get" && command.target === "report" && command.options.interval) {
+    command.command = 'report';
+    command.target = 'stolen';
   }
 
   var type    = command.command || command.name,

--- a/lib/agent/plugins/control-panel/index.js
+++ b/lib/agent/plugins/control-panel/index.js
@@ -107,8 +107,14 @@ function sync() {
     if (result.settings)
       update_settings(result.settings);
 
-    if (result.status && result.status.missing == true)
-      missing(result.status.delay);
+    if (result.status && result.status.missing === true) {
+      var opts = {
+        interval: result.status.delay || 20,
+        exclude: result.status.exclude
+      };
+
+      missing(opts);
+    }
 
     if (result.running_actions && result.running_actions.length > 1) {
       logger.warn('Restarting ' + result.running_actions.length + ' actions!');
@@ -141,6 +147,11 @@ function update_settings(obj) {
     process(obj.local, common.config);
 }
 
+function missing(opts) {
+  logger.info('Holy mother of satan! Device seems to be missing!');
+  commands.run('report', 'stolen', opts);
+}
+
 function scan_hardware() {
   commands.run('get', 'specs');
 }
@@ -153,12 +164,6 @@ function load_adapter(name, cb) {
     emitter.on('woken', adapters.interval.check);
     emitter.on('command', commands.perform);
   });
-}
-
-function missing(interval) {
-  logger.info('Holy mother of satan! Device seems to be missing!');
-  var interval = interval || 20;
-  commands.run('report', 'stolen', { interval: interval });
 }
 
 function found() {

--- a/lib/agent/plugins/control-panel/test/main_load.js
+++ b/lib/agent/plugins/control-panel/test/main_load.js
@@ -428,7 +428,7 @@ describe('main.load', function() {
           status_stub.restore();
         });
 
-        it('callsback no errors', function(done) {
+        it('callbacks with no errors', function(done) {
 
           call(function(err) {
             should.not.exist(err);

--- a/lib/agent/plugins/control-panel/test/main_load.js
+++ b/lib/agent/plugins/control-panel/test/main_load.js
@@ -33,8 +33,8 @@ describe('main.load', function() {
     hooks    : hooks,
     logger   : common.logger,
     config   : config,
-    commands : { perform: function(cmd) { /* noop */ } }, 
-    helpers  : { running_on_background: function() { return background } } 
+    commands : { perform: function(cmd) { /* noop */ } },
+    helpers  : { running_on_background: function() { return background } }
   }
 
   var call = function(cb) {
@@ -51,8 +51,8 @@ describe('main.load', function() {
 
   var setup_stub;
 
-  var stub_setup = function() { 
-    setup_stub = sinon.stub(setup, 'start', function(obk, cb) { 
+  var stub_setup = function() {
+    setup_stub = sinon.stub(setup, 'start', function(obk, cb) {
       cb(new Error('Setup worked, but were stopping here.'));
     })
   }
@@ -212,13 +212,13 @@ describe('main.load', function() {
             needle_stub.restore();
             keys_stub.restore();
             done();
-          })
+          });
 
-        })
+        });
 
-      })
+      });
 
-    })
+    });
 
     describe('without callback', function() {
 
@@ -237,9 +237,9 @@ describe('main.load', function() {
           done();
         }, 10);
 
-      })
+      });
 
-    })
+    });
 
   })
 
@@ -250,15 +250,15 @@ describe('main.load', function() {
       config.set('protocol', default_protocol); 
 
       background = false; // so we get a callback
-    })
+    });
 
     it('calls setup()', function(done) {
       call(function(err) {
         should.exist(err);
         err.message.should.eql('Setup worked, but were stopping here.');
         done();
-      })
-    })
+      });
+    });
 
     describe('if setup() failed', function() {
 
@@ -271,20 +271,20 @@ describe('main.load', function() {
 
         before(function() {
           background = true;
-          common.logger.pause()
+          common.logger.pause();
 
           // playing with fire here!
           setinterval_stub = sinon.stub(global, 'setInterval', function(fn, delay) { 
-            if (delay === 10000) 
+            if (delay === 10000)
               setinterval_called = true;
           });
 
-        })
+        });
 
         after(function() {
           setinterval_stub.restore(); // or heaven will fall apart
-          common.logger.resume()
-        })
+          common.logger.resume();
+        });
 
         it ('does not callback', function(done) {
           var called_back = false;
@@ -297,7 +297,7 @@ describe('main.load', function() {
             called_back.should.be.false;
             done();
           }, 20)
-        })
+        });
 
         it ('waits for config', function(done) {
 
@@ -308,7 +308,7 @@ describe('main.load', function() {
             setinterval_called.should.be.true;
             done();
           }, 20)
-        })
+        });
 
       })
 
@@ -323,21 +323,21 @@ describe('main.load', function() {
             should.exist(err);
             err.message.should.eql('Setup worked, but were stopping here.');
             done();
-          })
-        })
+          });
+        });
 
-      })
+      });
 
-    })
+    });
 
     describe('if setup() succeeded', function() {
 
       var stubs = [];
 
       // generic empty callback function with ultramegasuper callback position detection
-      var fn    = function() { 
+      var fn = function() {
         var cb;
-        
+
         // find callback in arguments
         for (var i = 0; i < arguments.length; i++) {
           if (typeof arguments[i] == 'function')
@@ -345,7 +345,7 @@ describe('main.load', function() {
         }
 
         cb && cb();
-      }; 
+      };
 
       before(function() {
         // first, reset the setup_stub defined at the start
@@ -355,7 +355,7 @@ describe('main.load', function() {
         stubs.push(sinon.stub(interval, 'load', fn));
         stubs.push(sinon.stub(push, 'load', fn));
         stubs.push(sinon.stub(api.devices.get, 'status', fn));
-      })
+      });
 
       after(function() {
         // now reset own own stubs
@@ -363,16 +363,16 @@ describe('main.load', function() {
 
         // reset the setup_stub back to original
         stub_setup();
-      })
+      });
 
       it('callsback no errors', function(done) {
 
         call(function(err) {
           should.not.exist(err);
           done();
-        })
+        });
 
-      })
+      });
 
       it('boots', function(done) {
 
@@ -381,15 +381,15 @@ describe('main.load', function() {
           // all stubs should have beenc called
           stubs.forEach(function(s) {
             s.called.should.be.true;
-          })
+          });
 
-          done()
-        })
+          done();
+        });
 
-      })
+      });
 
-    })
+    });
 
-  })
+  });
 
-})
+});

--- a/lib/agent/plugins/control-panel/test/main_load.js
+++ b/lib/agent/plugins/control-panel/test/main_load.js
@@ -334,7 +334,8 @@ describe('main.load', function() {
 
     describe('if setup() succeeded', function() {
 
-      var stubs = [];
+      var stubs = [],
+          status_stub;
 
       // generic empty callback function with ultramegasuper callback position detection
       var fn = function() {
@@ -353,6 +354,8 @@ describe('main.load', function() {
         // first, reset the setup_stub defined at the start
         setup_stub.restore();
         stubs.push(sinon.stub(setup, 'start', fn));
+        stubs.push(sinon.stub(interval, 'load', fn));
+        stubs.push(sinon.stub(push, 'load', fn));
       });
 
       after(function() {
@@ -371,8 +374,6 @@ describe('main.load', function() {
             }
           }
         };
-
-        var status_stub;
 
         before(function() {
           status_stub = sinon.stub(api.devices.get, 'status', function(cb) {
@@ -420,9 +421,11 @@ describe('main.load', function() {
       describe('with generic stubs', function() {
 
         before(function() {
-          stubs.push(sinon.stub(interval, 'load', fn));
-          stubs.push(sinon.stub(push, 'load', fn));
-          stubs.push(sinon.stub(api.devices.get, 'status', fn));
+          status_stub = sinon.stub(api.devices.get, 'status', fn)
+        });
+
+        after(function() {
+          status_stub.restore();
         });
 
         it('callsback no errors', function(done) {

--- a/lib/agent/plugins/control-panel/test/main_load.js
+++ b/lib/agent/plugins/control-panel/test/main_load.js
@@ -33,7 +33,9 @@ describe('main.load', function() {
     hooks    : hooks,
     logger   : common.logger,
     config   : config,
-    commands : { perform: function(cmd) { /* noop */ } },
+    commands : {
+      perform: function(cmd) { /* noop */ },
+    },
     helpers  : { running_on_background: function() { return background } }
   }
 
@@ -350,40 +352,100 @@ describe('main.load', function() {
       before(function() {
         // first, reset the setup_stub defined at the start
         setup_stub.restore();
-
-        stubs.push(sinon.stub(setup, 'start', fn))
-        stubs.push(sinon.stub(interval, 'load', fn));
-        stubs.push(sinon.stub(push, 'load', fn));
-        stubs.push(sinon.stub(api.devices.get, 'status', fn));
+        stubs.push(sinon.stub(setup, 'start', fn));
       });
 
       after(function() {
-        // now reset own own stubs
-        stubs.forEach(function(s) { s.restore() })
-
-        // reset the setup_stub back to original
+        stubs.forEach(function(s) { s.restore() });
         stub_setup();
       });
 
-      it('callsback no errors', function(done) {
+      describe('sync', function() {
 
-        call(function(err) {
-          should.not.exist(err);
-          done();
+        var response = {
+          body: {
+            status: {
+              missing: true,
+              delay: 2,
+              exclude: ['picture', 'screenshot']
+            }
+          }
+        };
+
+        var status_stub;
+
+        before(function() {
+          status_stub = sinon.stub(api.devices.get, 'status', function(cb) {
+            return cb(null, response);
+          });
+        });
+
+        after(function() {
+          status_stub.restore();
+        });
+
+        describe('when missing', function() {
+
+          it('trigger report with exclude options', function(done) {
+            var common_dup = {
+              hooks    : hooks,
+              logger   : common.logger,
+              config   : config,
+              commands : {
+                perform: sinon.spy(),
+                run: sinon.spy(),
+              },
+              helpers  : { running_on_background: function() { return background } }
+            }
+
+            common_dup.commands.perform = sinon.spy();
+
+            var missing_opts = {
+              interval: response.body.status.delay,
+              exclude: response.body.status.exclude
+            }
+
+            main.load.call(common_dup, function(err) {
+              common_dup.commands.run.callCount.should.equal(1);
+              common_dup.commands.run.firstCall.args[0].should.equal('report');
+              common_dup.commands.run.firstCall.args[1].should.equal('stolen');
+              common_dup.commands.run.firstCall.args[2].should.eql(missing_opts);
+              done();
+            });
+          });
         });
 
       });
 
-      it('boots', function(done) {
+      describe('with generic stubs', function() {
 
-        call(function() {
+        before(function() {
+          stubs.push(sinon.stub(interval, 'load', fn));
+          stubs.push(sinon.stub(push, 'load', fn));
+          stubs.push(sinon.stub(api.devices.get, 'status', fn));
+        });
 
-          // all stubs should have beenc called
-          stubs.forEach(function(s) {
-            s.called.should.be.true;
+        it('callsback no errors', function(done) {
+
+          call(function(err) {
+            should.not.exist(err);
+            done();
           });
 
-          done();
+        });
+
+        it('boots', function(done) {
+
+          call(function() {
+
+            // all stubs should have beenc called
+            stubs.forEach(function(s) {
+              s.called.should.be.true;
+            });
+
+            done();
+          });
+
         });
 
       });

--- a/test/lib/agent/commands.js
+++ b/test/lib/agent/commands.js
@@ -3,6 +3,7 @@ var helpers = require('./../../helpers'),
     sinon = require('sinon'),
     commands = helpers.load('commands'),
     reports = helpers.load('reports'),
+    storage   = helpers.load('utils/storage');
     hooks = helpers.load('hooks');
 
 describe('perform', function() {
@@ -13,7 +14,7 @@ describe('perform', function() {
         report_stub;
 
     beforeEach(function() {
-      // stub reports.get so it doesn't gather a report
+      // stub reports.get so it doesn't gather a report when triggering the command
       report_stub = sinon.stub(reports, 'get', function(report_name, options, callback) {
         return true;
       });
@@ -39,7 +40,19 @@ describe('perform', function() {
 
     });
 
-    it('persist the command', function() {});
+    it('persist the command', function(done) {
+
+      var stub = sinon.stub(storage, 'set', function(key, data, cb) {
+        key.should.equal("report-stolen");
+        data.should.eql(command);
+        stub.restore();
+        done();
+      });
+
+      commands.start_watching();
+      commands.perform(command);
+
+    });
 
   });
 

--- a/test/lib/agent/commands.js
+++ b/test/lib/agent/commands.js
@@ -1,0 +1,46 @@
+var helpers = require('./../../helpers'),
+    should = require('should'),
+    sinon = require('sinon'),
+    commands = helpers.load('commands'),
+    reports = helpers.load('reports'),
+    hooks = helpers.load('hooks');
+
+describe('perform', function() {
+
+  describe('when receiving a get report command', function() {
+
+    var command = {command: 'get', target: 'report', options: {interval: 5, exclude: ['picture']}},
+        report_stub;
+
+    beforeEach(function() {
+      // stub reports.get so it doesn't gather a report
+      report_stub = sinon.stub(reports, 'get', function(report_name, options, callback) {
+        return true;
+      });
+    });
+
+    afterEach(function() {
+      report_stub.restore();
+    });
+
+    it('triggers the command hook with the right params', function(done) {
+
+      function command_assertion(method, target, options) {
+        method.should.equal(reports.get);
+        target.should.equal('stolen');
+        options.should.equal(command.options);
+        hooks.remove('command', command_assertion);
+        done();
+      }
+
+      hooks.on('command', command_assertion);
+
+      commands.perform(command);
+
+    });
+
+    it('persist the command', function() {});
+
+  });
+
+});


### PR DESCRIPTION
This PR adds the following:

- The report command is persisted when the command signature is something like `{command: 'get', target: 'report', options: {interval: 5, exclude: ['picture']}}`.
- Control-panel plugin now takes into consideration the exclusions (picture and/or screenshot) when receiving missing instructions through the `status.json` end-point.