### PR TITLE
Fixed wrong camera selection for Surface tablets

### DIFF
--- a/lib/agent/providers/webcam/windows/index.js
+++ b/lib/agent/providers/webcam/windows/index.js
@@ -4,7 +4,7 @@ var exec = require('child_process').exec,
 exports.get_picture = function(file, callback){
 
   var cmd = '"' + join(__dirname, '/prey-webcam.exe') + '"';
-  cmd += ' -invalid youcam,cyberlink,google -frame 10 -outfile ' + file;
+  cmd += ' -invalid youcam,cyberlink,google,rear -frame 10 -outfile ' + file;
 
   exec(cmd, function(err) {
     callback(err, 'image/jpeg'); // if err exists, content_type will not matter


### PR DESCRIPTION
On Microsoft Surface tablets, Prey takes pictures with the rear camera by default. This isn't really practical, as it is unlikely to provide relevant information.

The cameras on Surface tablets are identified as "Microsoft Camera Front" and "Microsoft Camera Rear", therefore adding `rear` to the `-invalid` parameter for `prey-webcam.exe` forces Prey to use the front camera, as is intended.

Successfully tested on Surface 3, should in theory also work for Surface Pro 3, Surface Pro 4, Surface Book, and possibly older models as well.

Related: #98