### PR TITLE
Use correct OS version on user-agent

### DIFF
--- a/lib/system/index.js
+++ b/lib/system/index.js
@@ -25,11 +25,7 @@ var capitalize = function(str) {
 module.exports    = system;
 system.os_name    = os_name;
 system.get_os_version(function(err, os_version){
-<<<<<<< Updated upstream
-  system.user_agent = 'Prey/' + version + ' (Node '+ process.version + ' ' + system.os_name[0].toUpperCase() + system.os_name.slice(1) + ' ' + os_version + ')';
-=======
   system.user_agent = 'Prey/' + version + ' ('+ system.os_name[0].toUpperCase() + system.os_name.slice(1) + ' ' + os_version + ')';
->>>>>>> Stashed changes
 });
 
 system.paths      = require('./paths');

--- a/lib/system/index.js
+++ b/lib/system/index.js
@@ -25,7 +25,11 @@ var capitalize = function(str) {
 module.exports    = system;
 system.os_name    = os_name;
 system.get_os_version(function(err, os_version){
+<<<<<<< Updated upstream
   system.user_agent = 'Prey/' + version + ' (Node '+ process.version + ' ' + system.os_name[0].toUpperCase() + system.os_name.slice(1) + ' ' + os_version + ')';
+=======
+  system.user_agent = 'Prey/' + version + ' ('+ system.os_name[0].toUpperCase() + system.os_name.slice(1) + ' ' + os_version + ')';
+>>>>>>> Stashed changes
 });
 
 system.paths      = require('./paths');

--- a/lib/system/index.js
+++ b/lib/system/index.js
@@ -24,8 +24,10 @@ var capitalize = function(str) {
 
 module.exports    = system;
 system.os_name    = os_name;
-system.os_release = os.release();
-system.user_agent = 'Prey/' + version + ' (Node '+ process.version + ' ' + system.os_name[0].toUpperCase() + system.os_name.slice(1) + ' ' + system.os_release + ')';
+system.get_os_version(function(err, os_version){
+  system.user_agent = 'Prey/' + version + ' (Node '+ process.version + ' ' + system.os_name[0].toUpperCase() + system.os_name.slice(1) + ' ' + os_version + ')';
+});
+
 system.paths      = require('./paths');
 
 // bin/scripts for as_logged_user


### PR DESCRIPTION
This PR fixes a problem setting requests' user-agent, because node's os.release() function returns a wrong OSX version.