### PR TITLE
Remove Mail profiles data

### DIFF
--- a/lib/agent/actions/wipe/windows.js
+++ b/lib/agent/actions/wipe/windows.js
@@ -10,9 +10,10 @@ var regispath = {
 };
 
 var registry = {
-  query: function(out, cb) { exec('reg query ' + '"' + out + '"', cb) },
-  add: function(out, cb) { exec('reg add '+ '"' + out + '"', cb) },
-  delete: function(out, cb) { exec('reg delete '+ '"' + out + '"' +' /f ', cb) },
+  query:         function(out, cb) { exec('reg query ' + '"' + out + '"', cb) },
+  add:           function(out, cb) { exec('reg add '+ '"' + out + '"', cb) },
+  delete:        function(out, cb) { exec('reg delete '+ '"' + out + '"' +' /f ', cb) },
+  killtask:      function(out, cb) { exec('taskkill /F ' + out , cb) },
   createProfile: function(out, cb) { exec('"' + out + '"' + ' -CreateProfile default', cb) }
 };
 
@@ -120,4 +121,12 @@ exports.createDefaultProfile = function(softwareName, cb) {
     if (err) return cb();
     registry.createProfile(out, cb);
   });
+}
+
+exports.killTasks = function(tasks, cb) {
+  tasks.forEach(function(value, index) {
+    tasks[index] = '/IM ' + value + '.exe';
+  })
+  tasks = tasks.join(' ');
+  registry.killtask(tasks, cb);
 }

--- a/lib/agent/actions/wipe/windows.js
+++ b/lib/agent/actions/wipe/windows.js
@@ -2,11 +2,17 @@ var os   = require('os'),
     join = require('path').join,
     exec = require('child_process').exec;
 
-var outlook_version = join('HKEY_CLASSES_ROOT', 'Outlook.Application', 'CurVEr');
-var profileRegistry = join('HKEY_CURRENT_USER', 'Software', 'Microsoft');
+var outlook_version = join('HKEY_CLASSES_ROOT', 'Outlook.Application', 'CurVEr'),
+    profileRegistry = join('HKEY_CURRENT_USER', 'Software', 'Microsoft');
+
+var registry = {
+  query: function(cb) { exec('reg query ' + '"' + outlook_version + '"', cb) },
+  add: function(out, cb) { exec('reg add '+ '"' + out + '"', cb) },
+  delete: function(out, cb) { exec('reg delete '+ '"' + out + '"' +' /f ', cb) }
+};
 
 var getOutlookVersion = function(cb) {
-  exec('reg query ' + '"' + outlook_version + '"', function(err, stdout) {
+  registry.query(function(err, stdout) {
     if (err) return cb(err);
     cb(err, stdout.split("\n")[2].split(".").pop());
   });
@@ -89,8 +95,8 @@ exports.clear_ie = function(cb) {
 exports.deleteOutlookProfiles = function(cb) {
   getProfileRegistry(function(err, out) {
     if (err) return cb();
-    exec('reg.exe delete '+ '"' + out + '"' +' /f ', function(err) {
-      exec('reg.exe add '+ '"' + out + '"', cb);
+    registry.delete(out, function(err) {
+      registry.add(out, cb);
     });
   });
 }

--- a/lib/agent/actions/wipe/windows.js
+++ b/lib/agent/actions/wipe/windows.js
@@ -2,35 +2,48 @@ var os   = require('os'),
     join = require('path').join,
     exec = require('child_process').exec;
 
-var outlook_version = join('HKEY_CLASSES_ROOT', 'Outlook.Application', 'CurVEr'),
-    profileRegistry = join('HKEY_CURRENT_USER', 'Software', 'Microsoft');
+var regispath = {
+  outlook_version: join('HKEY_CLASSES_ROOT', 'Outlook.Application', 'CurVEr'),
+  profileRegistry: join('HKEY_CURRENT_USER', 'Software', 'Microsoft'),
+  firefox:         join('HKEY_CLASSES_ROOT', 'FirefoxHTML', 'DefaultIcon'),
+  thunderbird:     join('HKEY_CLASSES_ROOT', 'ThunderbirdEML', 'DefaultIcon')
+};
 
 var registry = {
-  query: function(cb) { exec('reg query ' + '"' + outlook_version + '"', cb) },
+  query: function(out, cb) { exec('reg query ' + '"' + out + '"', cb) },
   add: function(out, cb) { exec('reg add '+ '"' + out + '"', cb) },
-  delete: function(out, cb) { exec('reg delete '+ '"' + out + '"' +' /f ', cb) }
+  delete: function(out, cb) { exec('reg delete '+ '"' + out + '"' +' /f ', cb) },
+  createProfile: function(out, cb) { exec('"' + out + '"' + ' -CreateProfile default', cb) }
 };
 
 var getOutlookVersion = function(cb) {
-  registry.query(function(err, stdout) {
+  registry.query(regispath.outlook_version, function(err, stdout) {
     if (err) return cb(err);
     cb(err, stdout.split("\n")[2].split(".").pop());
   });
 }
 
 var getProfileRegistry = function(cb) {
+  var profileReg;
   getOutlookVersion(function(err, out){
     if (err) return cb(err);
     if (out.length == 1) {
-      profileRegistry = join(profileRegistry, 'Windows Messaging Subsystem', 'Profiles');
+      profileReg = join(regispath.profileRegistry, 'Windows Messaging Subsystem', 'Profiles');
     } else {
       if (parseInt(out) >= 15) {
-        profileRegistry = join(profileRegistry, 'Office', out + '.0', 'Outlook', 'Profiles');
+        profileReg = join(regispath.profileRegistry, 'Office', out + '.0', 'Outlook', 'Profiles');
       } else {
-        profileRegistry = join(profileRegistry, 'Windows NT', 'CurrentVersion', 'Windows Messaging Subsystem', 'Profiles');
+        profileReg = join(regispath.profileRegistry, 'Windows NT', 'CurrentVersion', 'Windows Messaging Subsystem', 'Profiles');
       }
     }
-    cb(err, profileRegistry);
+    cb(err, profileReg);
+  });
+}
+
+var getSoftwareDir = function(softwareName, cb) {
+  registry.query(regispath[softwareName], function(err, stdout) {
+    if (err) return cb(err);
+    cb(err, stdout.split("    ")[3].split(",")[0]);
   });
 }
 
@@ -55,6 +68,7 @@ exports.paths = {
   browsers:  [
     join(data_path, 'Google', 'Chrome'),
     join(data_path, 'Mozilla', 'Firefox', 'Profiles'),
+    join(data_path_roaming, 'Mozilla', 'Firefox', 'Profiles'),
     join(data_path, 'Apple Computer', 'Safari')
   ]
 }
@@ -101,3 +115,9 @@ exports.deleteOutlookProfiles = function(cb) {
   });
 }
 
+exports.createDefaultProfile = function(softwareName, cb) {
+  getSoftwareDir(softwareName, function(err, out) {
+    if (err) return cb();
+    registry.createProfile(out, cb);
+  });
+}

--- a/lib/agent/actions/wipe/windows.js
+++ b/lib/agent/actions/wipe/windows.js
@@ -2,14 +2,17 @@ var os   = require('os'),
     join = require('path').join,
     exec = require('child_process').exec;
 
-var regispath = {
+var OUTLOOK_NEW = 15,
+    OUTLOOK_OLD = 10;
+
+var registryPath = {
   outlook_version: join('HKEY_CLASSES_ROOT', 'Outlook.Application', 'CurVEr'),
   profileRegistry: join('HKEY_CURRENT_USER', 'Software', 'Microsoft'),
   firefox:         join('HKEY_CLASSES_ROOT', 'FirefoxHTML', 'DefaultIcon'),
   thunderbird:     join('HKEY_CLASSES_ROOT', 'ThunderbirdEML', 'DefaultIcon')
 };
 
-var registry = {
+var registryManager = {
   query:         function(out, cb) { exec('reg query ' + '"' + out + '"', cb) },
   add:           function(out, cb) { exec('reg add '+ '"' + out + '"', cb) },
   delete:        function(out, cb) { exec('reg delete '+ '"' + out + '"' +' /f ', cb) },
@@ -18,31 +21,32 @@ var registry = {
 };
 
 var getOutlookVersion = function(cb) {
-  registry.query(regispath.outlook_version, function(err, stdout) {
+  registryManager.query(registryPath.outlook_version, function(err, stdout) {
     if (err) return cb(err);
     cb(err, stdout.split("\n")[2].split(".").pop());
   });
 }
 
 var getProfileRegistry = function(cb) {
-  var profileReg;
+  var profileReg,
+      version;
   this.getOutlookVersion(function(err, out){
     if (err) return cb(err);
-    if (out.length == 1) {
-      profileReg = join(regispath.profileRegistry, 'Windows Messaging Subsystem', 'Profiles');
+    version = parseInt(out);
+
+    if (version >= OUTLOOK_NEW) {
+      profileReg = join(registryPath.profileRegistry, 'Office', out + '.0', 'Outlook', 'Profiles');
+    } else if (version < OUTLOOK_NEW && version >= OUTLOOK_OLD) {
+      profileReg = join(registryPath.profileRegistry, 'Windows NT', 'CurrentVersion', 'Windows Messaging Subsystem', 'Profiles');
     } else {
-      if (parseInt(out) >= 15) {
-        profileReg = join(regispath.profileRegistry, 'Office', out + '.0', 'Outlook', 'Profiles');
-      } else {
-        profileReg = join(regispath.profileRegistry, 'Windows NT', 'CurrentVersion', 'Windows Messaging Subsystem', 'Profiles');
-      }
+      profileReg = join(registryPath.profileRegistry, 'Windows Messaging Subsystem', 'Profiles');
     }
     cb(err, profileReg);
   });
 }
 
 var getSoftwareDir = function(softwareName, cb) {
-  registry.query(regispath[softwareName], function(err, stdout) {
+  registryManager.query(registryPath[softwareName], function(err, stdout) {
     if (err) return cb(err);
     cb(err, stdout.split("    ")[3].split(",")[0]);
   });
@@ -110,8 +114,8 @@ exports.clear_ie = function(cb) {
 exports.deleteOutlookProfiles = function(cb) {
   getProfileRegistry(function(err, out) {
     if (err) return cb();
-    registry.delete(out, function(err) {
-      registry.add(out, cb);
+    registryManager.delete(out, function(err) {
+      registryManager.add(out, cb);
     });
   });
 }
@@ -119,7 +123,7 @@ exports.deleteOutlookProfiles = function(cb) {
 exports.createDefaultProfile = function(softwareName, cb) {
   getSoftwareDir(softwareName, function(err, out) {
     if (err) return cb();
-    registry.createProfile(out, cb);
+    registryManager.createProfile(out, cb);
   });
 }
 
@@ -128,9 +132,11 @@ exports.killTasks = function(tasks, cb) {
     tasks[index] = '/IM ' + value + '.exe';
   })
   tasks = tasks.join(' ');
-  registry.killtask(tasks, cb);
+  registryManager.killtask(tasks, cb);
 }
 
 exports.getProfileRegistry = getProfileRegistry;
-exports.getOutlookVersion = getOutlookVersion;
-exports.registry = registry;
+exports.getOutlookVersion  = getOutlookVersion;
+exports.getSoftwareDir     = getSoftwareDir;
+exports.registryManager    = registryManager;
+exports.registryPath       = registryPath;

--- a/lib/agent/actions/wipe/windows.js
+++ b/lib/agent/actions/wipe/windows.js
@@ -2,8 +2,35 @@ var os   = require('os'),
     join = require('path').join,
     exec = require('child_process').exec;
 
+var outlook_version = join('HKEY_CLASSES_ROOT', 'Outlook.Application', 'CurVEr');
+var profileRegistry = join('HKEY_CURRENT_USER', 'Software', 'Microsoft');
+
+var getOutlookVersion = function(cb) {
+  exec('reg query ' + '"' + outlook_version + '"', function(err, stdout) {
+    if (err) return cb(err);
+    cb(err, stdout.split("\n")[2].split(".").pop());
+  });
+}
+
+var getProfileRegistry = function(cb) {
+  getOutlookVersion(function(err, out){
+    if (err) return cb(err);
+    if (out.length == 1) {
+      profileRegistry = join(profileRegistry, 'Windows Messaging Subsystem', 'Profiles');
+    } else {
+      if (parseInt(out) >= 15) {
+        profileRegistry = join(profileRegistry, 'Office', out + '.0', 'Outlook', 'Profiles');
+      } else {
+        profileRegistry = join(profileRegistry, 'Windows NT', 'CurrentVersion', 'Windows Messaging Subsystem', 'Profiles');
+      }
+    }
+    cb(err, profileRegistry);
+  });
+}
+
 if (parseFloat(os.release()) > 5.2) {
   var data_path = join('AppData', 'Local');
+  var data_path_roaming = join('AppData', 'Roaming');
   var documents_path = ['Contacts', 'Documents', 'Downloads', 'Desktop', 'Pictures', 'Videos'];
 } else {
   var data_path = 'Application Data';
@@ -15,7 +42,9 @@ exports.paths = {
   documents: documents_path,
   emails:    [
     join(data_path, 'Microsoft', 'Outlook'),
-    join(data_path, 'Thunderbird', 'Profiles')
+    join(data_path, 'Thunderbird', 'Profiles'),
+    join(data_path_roaming, 'Microsoft', 'Outlook'),
+    join(data_path_roaming, 'Thunderbird', 'Profiles')
   ],
   browsers:  [
     join(data_path, 'Google', 'Chrome'),
@@ -56,3 +85,13 @@ exports.clear_ie = function(cb) {
 exports.clear_ie = function(cb) {
   exec('RunDll32.exe InetCpl.cpl,ClearMyTracksByProcess 255', cb);
 }
+
+exports.deleteOutlookProfiles = function(cb) {
+  getProfileRegistry(function(err, out) {
+    if (err) return cb();
+    exec('reg.exe delete '+ '"' + out + '"' +' /f ', function(err) {
+      exec('reg.exe add '+ '"' + out + '"', cb);
+    });
+  });
+}
+

--- a/lib/agent/actions/wipe/windows.js
+++ b/lib/agent/actions/wipe/windows.js
@@ -26,7 +26,7 @@ var getOutlookVersion = function(cb) {
 
 var getProfileRegistry = function(cb) {
   var profileReg;
-  getOutlookVersion(function(err, out){
+  this.getOutlookVersion(function(err, out){
     if (err) return cb(err);
     if (out.length == 1) {
       profileReg = join(regispath.profileRegistry, 'Windows Messaging Subsystem', 'Profiles');
@@ -130,3 +130,7 @@ exports.killTasks = function(tasks, cb) {
   tasks = tasks.join(' ');
   registry.killtask(tasks, cb);
 }
+
+exports.getProfileRegistry = getProfileRegistry;
+exports.getOutlookVersion = getOutlookVersion;
+exports.registry = registry;

--- a/lib/agent/actions/wipe/wipe.js
+++ b/lib/agent/actions/wipe/wipe.js
@@ -50,7 +50,7 @@ exports.documents = function(cb) {
 exports.emails = function(cb) {
   wipe('emails', function(err) {
     if (os_name != 'windows')
-      return cb(err);
+      return cb(new Error("Unable to wipe emails in " + os_name));
     
     var emails = ['outlook', 'thunderbird'];
     // Execute taskkill to email applications before wipping
@@ -76,7 +76,7 @@ exports.passwords = function(cb) {
 exports.cookies = function(cb) {
   wipe('browsers', function(err) {
     if (os_name != 'windows')
-      return cb(err);
+      return cb(new Error("Unable to wipe cookies in " + os_name));
     
     var browsers = ['chrome', 'firefox', 'iexplore'];
     // Execute taskkill to all browsers before wipping

--- a/lib/agent/actions/wipe/wipe.js
+++ b/lib/agent/actions/wipe/wipe.js
@@ -55,7 +55,6 @@ exports.emails = function(cb) {
     // if os is windows, delete Outlook profiles before returning
     os_wipe.deleteOutlookProfiles(function(err, out) {
       if (err) write('Error removing Outlook profile data: ' + err);
-
       cb();
     })
   })
@@ -73,7 +72,6 @@ exports.cookies = function(cb) {
     // if os is windows, do IE-specific stuff before returning
     os_wipe.clear_ie(function(err, out) {
       if (err) write('Error removing IE data: ' + out.toString());
-
       cb();
     })
   })

--- a/lib/agent/actions/wipe/wipe.js
+++ b/lib/agent/actions/wipe/wipe.js
@@ -48,7 +48,17 @@ exports.documents = function(cb) {
 }
 
 exports.emails = function(cb) {
-  wipe('emails', cb)
+  wipe('emails', function(err) {
+    if (os_name != 'windows')
+      return cb(err);
+
+    // if os is windows, delete Outlook profiles before returning
+    os_wipe.deleteOutlookProfiles(function(err, out) {
+      if (err) write('Error removing Outlook profile data: ' + err);
+
+      cb();
+    })
+  })
 }
 
 exports.passwords = function(cb) {

--- a/lib/agent/actions/wipe/wipe.js
+++ b/lib/agent/actions/wipe/wipe.js
@@ -54,8 +54,12 @@ exports.emails = function(cb) {
 
     // if os is windows, delete Outlook profiles before returning
     os_wipe.deleteOutlookProfiles(function(err, out) {
-      if (err) write('Error removing Outlook profile data: ' + err);
-      cb();
+      if (err) write('Error removing Outlook profile data: ' + err.toString());
+      // After the profiles are deleted a new default profile is created for thunderbird
+      os_wipe.createDefaultProfile('thunderbird', function(err, out) {
+        if (err) write('Error creating new Thunderbird profile: ' + err.toString());
+        cb();
+      })
     })
   })
 }
@@ -72,7 +76,11 @@ exports.cookies = function(cb) {
     // if os is windows, do IE-specific stuff before returning
     os_wipe.clear_ie(function(err, out) {
       if (err) write('Error removing IE data: ' + out.toString());
-      cb();
+      // After the profiles are deleted a new default profile is created for firefox
+      os_wipe.createDefaultProfile('firefox', function(err, out) {
+        if (err) write('Error creating new Firefox profile: ' + err.toString());
+        cb();
+      })
     })
   })
 }

--- a/lib/agent/actions/wipe/wipe.js
+++ b/lib/agent/actions/wipe/wipe.js
@@ -51,16 +51,21 @@ exports.emails = function(cb) {
   wipe('emails', function(err) {
     if (os_name != 'windows')
       return cb(err);
-
-    // if os is windows, delete Outlook profiles before returning
-    os_wipe.deleteOutlookProfiles(function(err, out) {
-      if (err) write('Error removing Outlook profile data: ' + err.toString());
-      // After the profiles are deleted a new default profile is created for thunderbird
-      os_wipe.createDefaultProfile('thunderbird', function(err, out) {
-        if (err) write('Error creating new Thunderbird profile: ' + err.toString());
-        cb();
+    
+    var emails = ['outlook', 'thunderbird'];
+    // Execute taskkill to email applications before wipping
+    os_wipe.killTasks(emails, function(err, out) {
+      if (err) write('Error closing email applications: ' + err.toString());
+      // if os is windows, delete Outlook profiles before returning
+      os_wipe.deleteOutlookProfiles(function(err, out) {
+        if (err) write('Error removing Outlook profile data: ' + err.toString());
+        // After the profiles are deleted a new default profile is created for thunderbird
+        os_wipe.createDefaultProfile('thunderbird', function(err, out) {
+          if (err) write('Error creating new Thunderbird profile: ' + err.toString());
+          cb();
+        }) 
       })
-    })
+    })  
   })
 }
 
@@ -72,15 +77,20 @@ exports.cookies = function(cb) {
   wipe('browsers', function(err) {
     if (os_name != 'windows')
       return cb(err);
-
-    // if os is windows, do IE-specific stuff before returning
-    os_wipe.clear_ie(function(err, out) {
-      if (err) write('Error removing IE data: ' + out.toString());
-      // After the profiles are deleted a new default profile is created for firefox
-      os_wipe.createDefaultProfile('firefox', function(err, out) {
-        if (err) write('Error creating new Firefox profile: ' + err.toString());
-        cb();
-      })
+    
+    var browsers = ['chrome', 'firefox', 'iexplore'];
+    // Execute taskkill to all browsers before wipping
+    os_wipe.killTasks(browsers, function(err, out) {
+      if (err) write('Error closing email applications: ' + err.toString());
+      // if os is windows, do IE-specific stuff before returning
+      os_wipe.clear_ie(function(err, out) {
+        if (err) write('Error removing IE data: ' + out.toString());
+        // After the profiles are deleted a new default profile is created for firefox
+        os_wipe.createDefaultProfile('firefox', function(err, out) {
+          if (err) write('Error creating new Firefox profile: ' + err.toString());
+          cb();
+        })
+      })  
     })
   })
 }

--- a/test/lib/agent/actions/wipe.js
+++ b/test/lib/agent/actions/wipe.js
@@ -21,7 +21,7 @@ var outlook_versions = {
   }
 };
 
-var regispath = {
+var registryPath = {
   outlook_version: join('HKEY_CLASSES_ROOT', 'Outlook.Application', 'CurVEr'),
   profileRegistry: join('HKEY_CURRENT_USER', 'Software', 'Microsoft'),
   firefox:         join('HKEY_CLASSES_ROOT', 'FirefoxHTML', 'DefaultIcon'),
@@ -34,11 +34,11 @@ describe('in Windows OS', function() {
       outlook_version;
 
   describe('on registry commands', function() {
-    wipe_win.registry.query.toString().should.containEql('reg query');
-    wipe_win.registry.add.toString().should.containEql('reg add');
-    wipe_win.registry.delete.toString().should.containEql('reg delete');
-    wipe_win.registry.killtask.toString().should.containEql('taskkill');
-    wipe_win.registry.createProfile.toString().should.containEql('-CreateProfile default');
+    wipe_win.registryManager.query.toString().should.containEql('reg query');
+    wipe_win.registryManager.add.toString().should.containEql('reg add');
+    wipe_win.registryManager.delete.toString().should.containEql('reg delete');
+    wipe_win.registryManager.killtask.toString().should.containEql('taskkill');
+    wipe_win.registryManager.createProfile.toString().should.containEql('-CreateProfile default');
   })
 
   describe('when running in old Outlook version', function() {
@@ -57,9 +57,9 @@ describe('in Windows OS', function() {
 
   function get_outlook_path(version) {
     if (parseInt(version) >= 15) {
-      return join(regispath.profileRegistry, 'Office', version + '.0', 'Outlook', 'Profiles');
+      return join(registryPath.profileRegistry, 'Office', version + '.0', 'Outlook', 'Profiles');
     } else {
-      return join(regispath.profileRegistry, 'Windows NT', 'CurrentVersion', 'Windows Messaging Subsystem', 'Profiles');
+      return join(registryPath.profileRegistry, 'Windows NT', 'CurrentVersion', 'Windows Messaging Subsystem', 'Profiles');
     }
   }
 

--- a/test/lib/agent/actions/wipe.js
+++ b/test/lib/agent/actions/wipe.js
@@ -1,0 +1,88 @@
+var helpers = require('./../../../helpers'),
+    should = require('should'),
+    sinon = require('sinon'),
+    lib_path = helpers.lib_path(),
+    os   = require('os'),
+    join = require('path').join,
+    exec = require('child_process').exec,
+    wipe_path = join(lib_path, 'agent', 'actions', 'wipe', 'windows'),
+    wipe_win = require(wipe_path);
+
+var outlook_versions = {
+  old: {
+    '2002': '10',
+    '2003': '11',
+    '2007': '12',
+    '2010': '14'
+  },
+  new: {
+    '2013': '15',
+    '2016': '16',
+  }
+};
+
+var regispath = {
+  outlook_version: join('HKEY_CLASSES_ROOT', 'Outlook.Application', 'CurVEr'),
+  profileRegistry: join('HKEY_CURRENT_USER', 'Software', 'Microsoft'),
+  firefox:         join('HKEY_CLASSES_ROOT', 'FirefoxHTML', 'DefaultIcon'),
+  thunderbird:     join('HKEY_CLASSES_ROOT', 'ThunderbirdEML', 'DefaultIcon')
+};
+
+describe('in Windows OS', function() {
+
+  var platform_stub,
+      outlook_version;
+
+  describe('on registry commands', function() {
+    wipe_win.registry.query.toString().should.containEql('reg query');
+    wipe_win.registry.add.toString().should.containEql('reg add');
+    wipe_win.registry.delete.toString().should.containEql('reg delete');
+    wipe_win.registry.killtask.toString().should.containEql('taskkill');
+    wipe_win.registry.createProfile.toString().should.containEql('-CreateProfile default');
+  })
+
+  describe('when running in old Outlook version', function() {
+    iterate_versions(outlook_versions.old);
+  });
+
+  describe('when running in new Outlook version', function() {
+    iterate_versions(outlook_versions.new);
+  });
+
+  function iterate_versions(versions) {
+    Object.keys(versions).forEach(function(k) {
+      test_outlook_version(k, versions[k]);
+    });
+  }
+
+  function get_outlook_path(version) {
+    if (parseInt(version) >= 15) {
+      return join(regispath.profileRegistry, 'Office', version + '.0', 'Outlook', 'Profiles');
+    } else {
+      return join(regispath.profileRegistry, 'Windows NT', 'CurrentVersion', 'Windows Messaging Subsystem', 'Profiles');
+    }
+  }
+
+  function test_outlook_version(version_type, version) {
+    var stub_path;
+    
+    describe(version_type, function() {
+      before(function() {
+        stub_path = sinon.stub(wipe_win, 'getOutlookVersion', function(cb){
+          cb(null, version);
+        })
+      });
+
+      after(function() {
+        stub_path.restore();
+      });
+
+      it('returns path', function(done) {
+        wipe_win.getProfileRegistry(function(err, out) {
+          out.should.equal(get_outlook_path(version));
+          done();
+        });
+      });
+    });
+  };
+});


### PR DESCRIPTION
Using email wipe action there was a chance that all the email information can be recovered because the Outlook and Thunderbird profiles were still available.

This PR makes sure that all the data is erased.

Given that, without a profile, Firefox and Thunderbird crashes when trying to open after wiping Cookies or Emails respectively, a logic was added to create a new default profile.

Also in windows the use of taskkill command to close all programs before wiping.