### PR TITLE
Ensure UTF-8 codepage on prey install (Error 1603)

### DIFF
--- a/lib/conf/tasks/daemon.js
+++ b/lib/conf/tasks/daemon.js
@@ -13,14 +13,6 @@ var run = function(cmd, cb) {
   exec(cmd, cb)
 }
 
-var modify_cp = function(cb) {
-  if (is_windows) {
-    run('chcp 65001', cb);
-  } else {
-    cb();
-  }
-}
-
 if (is_windows) {
 
   var exe_name         = 'wpxsvc.exe',
@@ -93,15 +85,15 @@ exports.install = function(cb) {
 
       // wait one sec, then start. or half.
       setTimeout(function() {
-        modify_cp(function() {
-          satan.start(daemon_opts.key, cb);
-        });
+        satan.start(daemon_opts.key, cb);
       }, 500);
     });
   }
 
   if (is_windows) {
-    cp(service_bin, service_run_path, next);
+    run('chcp 65001', function() {
+      cp(service_bin, service_run_path, next);
+    });
   } else {
     next();
   }

--- a/lib/conf/tasks/daemon.js
+++ b/lib/conf/tasks/daemon.js
@@ -3,10 +3,15 @@ var fs         = require('fs'),
     paths      = require('./../../system/paths'),
     join       = require('path').join,
     cp         = require('../utils/cp').cp,
+    exec       = require('child_process').exec;
     is_windows = process.platform == 'win32';
 
 var bin_path   = join(paths.current, 'bin'),
     prey_user  = 'prey';
+
+var run = function(cmd, cb) {
+  exec(cmd, cb)
+}
 
 if (is_windows) {
 
@@ -80,7 +85,9 @@ exports.install = function(cb) {
 
       // wait one sec, then start. or half.
       setTimeout(function() {
-        satan.start(daemon_opts.key, cb);
+        run('chcp 65001', function() {
+          satan.start(daemon_opts.key, cb);
+        });
       }, 500);
     });
   }

--- a/lib/conf/tasks/daemon.js
+++ b/lib/conf/tasks/daemon.js
@@ -13,6 +13,14 @@ var run = function(cmd, cb) {
   exec(cmd, cb)
 }
 
+var modify_cp = function(cb) {
+  if (is_windows) {
+    run('chcp 65001', cb);
+  } else {
+    cb();
+  }
+}
+
 if (is_windows) {
 
   var exe_name         = 'wpxsvc.exe',
@@ -85,7 +93,7 @@ exports.install = function(cb) {
 
       // wait one sec, then start. or half.
       setTimeout(function() {
-        run('chcp 65001', function() {
+        modify_cp(function() {
           satan.start(daemon_opts.key, cb);
         });
       }, 500);


### PR DESCRIPTION
PR created in order to fix the issue https://github.com/prey/prey-node-client/issues/58

Several users reported errors during Prey installation on Windows, most of them with local language beyond latin alphabet. The error can be seen in the prey-install-log:

<img width="789" alt="screen shot 2016-07-25 at 16 25 58" src="https://cloud.githubusercontent.com/assets/11738416/17116103/3c9471a4-5284-11e6-87ff-df5cce75451e.png">

<img width="490" alt="screen shot 2016-07-25 at 16 36 12" src="https://cloud.githubusercontent.com/assets/11738416/17116412/a99c9456-5285-11e6-82e3-c296403b9b84.png">

The proposed solution is to change the default codepage during the installation process to '65001' (UTF-8). After this fix in the prey-install.log:

<img width="796" alt="screen shot 2016-07-25 at 16 29 26" src="https://cloud.githubusercontent.com/assets/11738416/17116200/b1d23ece-5284-11e6-94e5-7a28b8f82fdd.png">

And finally installation process works properly.