### PR TITLE
Commands handle using sqlite

### DIFF
--- a/lib/agent/actions/fileretrieval/storage.js
+++ b/lib/agent/actions/fileretrieval/storage.js
@@ -9,14 +9,14 @@ var join      = require('path').join,
 var logger   = common.logger;
     watching = false;
 
-var NAMESPACE = "fr/";
+var storage_path = join(common.system.paths.config, 'commands.db');
+storage.init('files', storage_path);
 
 var exist = function(id, cb) {
-  var key = NAMESPACE + id;
-  storage.all(function(err, files) {
+  storage.all('files', function(err, files) {
     if (err)
       return err.message;
-    if (files[key])
+    if (files[id])
       return cb(true);
     return cb(false);
   });
@@ -32,18 +32,18 @@ exports.store = function(id, path, size, user, name) {
         user: user,
         name: name
       }
-      storage.set(NAMESPACE + id, opts);
+      storage.set(id, opts);
     }
   });
 }
 
 exports.del = function(id) {
   logger.debug('Removing file_id from DB: ' + id);
-  storage.del(NAMESPACE + id);
+  storage.del(id);
 }
 
 exports.run_stored = function(cb) {
-  storage.all(function(err, files) {
+  storage.all('files', function(err, files) {
     if (err)
       return logger.error(err.message);
 
@@ -53,15 +53,12 @@ exports.run_stored = function(cb) {
     logger.warn('Re-uploading ' + count + ' pending files.');
 
     for (key in files) {
-      if(key.indexOf(NAMESPACE) != 0) {
-        continue;
-      }
       var opts = {
         path: files[key].path,
         user: files[key].user,
         name: files[key].name,
         size: files[key].size,
-        file_id: key.substring(3, key.length),
+        file_id: key,
         resumable: true
       }
       fileretrieval.start(opts, cb);

--- a/lib/agent/actions/fileretrieval/storage.js
+++ b/lib/agent/actions/fileretrieval/storage.js
@@ -10,7 +10,9 @@ var logger   = common.logger;
     watching = false;
 
 var storage_path = join(common.system.paths.config, 'commands.db');
-storage.init('files', storage_path);
+storage.init('files', storage_path, function(err) {
+  if (err) logger.error('Unable to initialize db for files: ' + err);
+});
 
 var exist = function(id, cb) {
   storage.all('files', function(err, files) {

--- a/lib/agent/commands.js
+++ b/lib/agent/commands.js
@@ -12,7 +12,7 @@ var logger    = common.logger;
 var watching  = false; // flag for storing new commands when fired
 
 var storage_path = join(common.system.paths.config, 'commands.db');
-storage.init(storage_path);
+storage.init('commands', storage_path);
 
 ////////////////////////////////////////////////////////////////////
 // helpers
@@ -199,7 +199,7 @@ exports.stop_watching = function() {
 }
 
 exports.run_stored = function(cb) {
-  storage.all(function(err, commands) {
+  storage.all('commands', function(err, commands) {
     if (err)
       return logger.error(err.message);
 
@@ -207,7 +207,7 @@ exports.run_stored = function(cb) {
     if (count <= 0)
       return;
 
-    storage.clear();
+    storage.clear('commands');
     logger.warn('Relaunching ' + count + ' commands previously in execution.');
 
     for (var key in commands)

--- a/lib/agent/commands.js
+++ b/lib/agent/commands.js
@@ -12,7 +12,9 @@ var logger    = common.logger;
 var watching  = false; // flag for storing new commands when fired
 
 var storage_path = join(common.system.paths.config, 'commands.db');
-storage.init('commands', storage_path);
+storage.init('commands', storage_path, function(err) {
+  if (err) logger.error('Unable to initialize db for commands: ' + err);
+});
 
 ////////////////////////////////////////////////////////////////////
 // helpers

--- a/lib/agent/utils/storage.js
+++ b/lib/agent/utils/storage.js
@@ -1,13 +1,30 @@
 var fs = require('fs'),
     sqlite3 = require('sqlite3').verbose();
 
-var db, db_path, db_comm;
+var db_path, db_type, db_comm;
 
-var load = function(cb) {
+var db_commands = {
+  CREATE: function(type) {return "CREATE TABLE IF NOT EXISTS " + type + " (" + singular(type) + " text)"},
+  INSERT: function(type) {return "INSERT INTO " + type + " VALUES (?)"},
+  SELECT: function(type) {return "SELECT * FROM " + type},
+  DELETE: function(type) {return "DELETE FROM " + type}
+}
+
+var singular = function(db_type) {
+  return db_type.substring(0, db_type.length - 1);
+}
+
+var check_type = function(key) {
+  if (key.indexOf('start') != -1) return 'commands';
+  else return 'files';
+}
+
+var load = function(type, cb) {
+  var db;
   if (!db_path)
     return cb(new Error('Invalid path'));
 
-  db_comm.all("SELECT * from commands", function(err, rows){
+  db_comm.all(db_commands.SELECT(type), function(err, rows) {
     if (err) {
       if (err.code != 'ENOENT')
         return cb(err); // only return error if different from ENOENT
@@ -17,58 +34,73 @@ var load = function(cb) {
     }
 
     try {
-      db = JSON.parse(new Buffer(rows[0]['command'], 'base64').toString());
+      var db1 = {};
+      for (var i = 0; i < rows.length; i++) {
+        var value = JSON.parse(new Buffer(rows[i][singular(type)], 'base64').toString());
+        for (var attr in value) { db1[attr] = value[attr] }
+      }
+      db = db1;
     } catch(e) {
       db = {};
     }
 
-    cb();
+    cb(db, null);
   })
 }
 
-var remove = function(cb) {
+var remove = function(type, cb) {
   if (!db_path) {
     // return cb(new Error('Invalid path'));
     return cb();
   }
-  db_comm.all("DELETE FROM commands", function(err) {
+
+  db_comm.all(db_commands.DELETE(type), function(err) {
     var e = err && err.code != 'ENOENT' ? err : null;
     return cb && cb(e);
   })
 }
 
-var save = function(cb) {
+var save = function(type, db, cb) {
   // if empty, just remove the thing
   if (Object.keys(db).length == 0) {
-    return remove(cb);
+    return remove(type, cb);
   }
-  remove(function() {
-    db_comm.run("CREATE TABLE IF NOT EXISTS commands (command text)");
-    var stmt = db_comm.prepare("INSERT INTO commands VALUES (?)");
-    var str = new Buffer(JSON.stringify(db, null, 0)).toString('base64');
-    stmt.run(str);
-    stmt.finalize();
-    return cb;
+
+  remove(type, function() {
+    db_comm.run(db_commands.CREATE(type), function(err) {
+      var stmt = db_comm.prepare(db_commands.INSERT(type)); 
+      for (var k in db) {
+        var db1 = {};
+        db1[k] = db[k];
+        
+        var str = new Buffer(JSON.stringify(db1, null, 0)).toString('base64');
+        stmt.run(str);
+      }
+      stmt.finalize();
+      return cb;
+    }); 
   });
 }
 
-exports.init = function(path) {
+exports.init = function(type, path) {
   db_path = path;
   db_comm = new sqlite3.Database(db_path);
-  db_comm.run("CREATE TABLE IF NOT EXISTS commands (command text)");
+  db_comm.run(db_commands.CREATE(type));
 }
 
 exports.set = function(key, data, cb) {
-  load(function(err) {
+  var type = check_type(key);
+  load(type, function(db, err) {
     if (err) return cb && cb(err);
 
     db[key] = data;
-    save(cb);
+    save(type, db, cb);
   })
 }
 
 exports.get = function(key, cb) {
-  load(function(err) {
+  var type = check_type(key);
+  load(type, function(db, err) {
     if (err) return cb && cb(err);
 
     cb(null, db[key]);
@@ -76,7 +108,8 @@ exports.get = function(key, cb) {
 }
 
 exports.del = function(key, cb) {
-  load(function(err) {
+  var type = check_type(key);
+  load(type, function(db, err) {
     if (err) return cb && cb(err);
 
     var found = false;
@@ -88,28 +121,26 @@ exports.del = function(key, cb) {
       }
     }
 
-    return found ? save(cb) : cb && cb();
+    return found ? save(type, db, cb) : cb && cb();
   })
 }
 
-exports.all = function(cb) {
-  load(function(err) {
+exports.all = function(type, cb) {
+  load(type, function(db, err) {
     if (err) return cb(err);
     cb && cb(null, db);
   })
 }
 
 // empties db and removes file
-exports.clear = function(cb) {
-  remove(function(err) {
-    db = {};
+exports.clear = function(type, cb) {
+  remove(type, function(err) {
     cb && cb(err);
   });
 }
 
-exports.close = function(cb) {
-  remove(function(err) {
-    db = null;
+exports.close = function(type, cb) {
+  remove(type, function(err) {
     db_path = null;
 
     cb && cb(err);

--- a/lib/agent/utils/storage.js
+++ b/lib/agent/utils/storage.js
@@ -14,23 +14,25 @@ var singular = function(db_type) {
   return db_type.substring(0, db_type.length - 1);
 }
 
-var check_type = function(key) {
-  if (key.indexOf('start') != -1) return 'commands';
-  else return 'files';
+var check_type = function(key, cb) {
+  if (key.indexOf('start') != -1) return cb(null, 'commands');
+  else if (key.length == 32 && key == key.toUpperCase()) return cb(null, 'files');
+  else return cb(new Error("Not commands or files"))
 }
 
 var load = function(type, cb) {
   var db;
-  if (!db_path)
-    return cb(new Error('Invalid path'));
+  if (!db_path) {
+    return cb(new Error('Invalid path'), null);
+  }
 
   db_comm.all(db_commands.SELECT(type), function(err, rows) {
     if (err) {
       if (err.code != 'ENOENT')
-        return cb(err); // only return error if different from ENOENT
+        return cb(err, null);
 
       db = {};
-      return cb();
+      return cb(err, db);
     }
 
     try {
@@ -44,7 +46,7 @@ var load = function(type, cb) {
       db = {};
     }
 
-    cb(db, null);
+    cb(null, db);
   })
 }
 
@@ -54,7 +56,7 @@ var remove = function(type, cb) {
     return cb();
   }
 
-  db_comm.all(db_commands.DELETE(type), function(err) {
+  db_comm.run(db_commands.DELETE(type), function(err) {
     var e = err && err.code != 'ENOENT' ? err : null;
     return cb && cb(e);
   })
@@ -77,56 +79,69 @@ var save = function(type, db, cb) {
         stmt.run(str);
       }
       stmt.finalize();
-      return cb;
+      return cb && cb(err);
     }); 
   });
 }
 
-exports.init = function(type, path) {
-  db_path = path;
-  db_comm = new sqlite3.Database(db_path);
-  db_comm.run(db_commands.CREATE(type));
+exports.init = function(type, path, cb) {
+  db_comm = new sqlite3.Database(path);
+  db_comm.run(db_commands.CREATE(type), function(err) {
+    db_path = path;
+    return cb && cb(err);
+  });
 }
 
 exports.set = function(key, data, cb) {
-  var type = check_type(key);
-  load(type, function(db, err) {
-    if (err) return cb && cb(err);
+  check_type(key, function(err, type){
+    if (err) cb(err);
+    load(type, function(err, db) {
 
-    db[key] = data;
-    save(type, db, cb);
-  })
+      if (err) return cb && cb(err);
+
+      db[key] = data;
+      save(type, db, cb);
+    })
+  });
 }
 
 exports.get = function(key, cb) {
-  var type = check_type(key);
-  load(type, function(db, err) {
+  check_type(key, function(err, type){
     if (err) return cb && cb(err);
 
-    cb(null, db[key]);
-  })
+    load(type, function(err, db) {
+
+      if (err) {
+        return cb && cb(err);
+      }
+
+      cb(null, db[key]);
+    })
+  });
 }
 
 exports.del = function(key, cb) {
-  var type = check_type(key);
-  load(type, function(db, err) {
-    if (err) return cb && cb(err);
+  check_type(key, function(err, type){
+    if (err) cb(err);
+    load(type, function(err, db) {
+      if (err) return cb && cb(err);
 
-    var found = false;
+      var found = false;
 
-    for (var k in db) {
-      if (k == key) {
-        found = true;
-        delete db[key];
+      for (var k in db) {
+        if (k == key) {
+          found = true;
+          delete db[key];
+        }
       }
-    }
 
-    return found ? save(type, db, cb) : cb && cb();
-  })
+      return found ? save(type, db, cb) : cb && cb();
+    })
+  });
 }
 
 exports.all = function(type, cb) {
-  load(type, function(db, err) {
+  load(type, function(err, db) {
     if (err) return cb(err);
     cb && cb(null, db);
   })
@@ -141,6 +156,14 @@ exports.clear = function(type, cb) {
 
 exports.close = function(type, cb) {
   remove(type, function(err) {
+    db_path = null;
+
+    cb && cb(err);
+  })
+}
+
+exports.erase = function(path, cb) {
+  fs.unlink(path, function(err) {
     db_path = null;
 
     cb && cb(err);

--- a/lib/agent/utils/storage.js
+++ b/lib/agent/utils/storage.js
@@ -1,14 +1,13 @@
-var fs = require('fs');
-var db, db_path;
+var fs = require('fs'),
+    sqlite3 = require('sqlite3').verbose();
+
+var db, db_path, db_comm;
 
 var load = function(cb) {
-  if (db)
-    return cb();
-
   if (!db_path)
     return cb(new Error('Invalid path'));
 
-  fs.readFile(db_path, 'utf8', function(err, data) {
+  db_comm.all("SELECT * from commands", function(err, rows){
     if (err) {
       if (err.code != 'ENOENT')
         return cb(err); // only return error if different from ENOENT
@@ -18,7 +17,7 @@ var load = function(cb) {
     }
 
     try {
-      db = JSON.parse(new Buffer(data, 'base64').toString());
+      db = JSON.parse(new Buffer(rows[0]['command'], 'base64').toString());
     } catch(e) {
       db = {};
     }
@@ -32,8 +31,7 @@ var remove = function(cb) {
     // return cb(new Error('Invalid path'));
     return cb();
   }
-
-  fs.unlink(db_path, function(err) {
+  db_comm.all("DELETE FROM commands", function(err) {
     var e = err && err.code != 'ENOENT' ? err : null;
     return cb && cb(e);
   })
@@ -44,16 +42,20 @@ var save = function(cb) {
   if (Object.keys(db).length == 0) {
     return remove(cb);
   }
-
-  var str = new Buffer(JSON.stringify(db, null, 0)).toString('base64');
-
-  fs.writeFile(db_path, str, function(err) {
-    return cb && cb(err);
-  })
+  remove(function() {
+    db_comm.run("CREATE TABLE IF NOT EXISTS commands (command text)");
+    var stmt = db_comm.prepare("INSERT INTO commands VALUES (?)");
+    var str = new Buffer(JSON.stringify(db, null, 0)).toString('base64');
+    stmt.run(str);
+    stmt.finalize();
+    return cb;
+  });
 }
 
 exports.init = function(path) {
   db_path = path;
+  db_comm = new sqlite3.Database(db_path);
+  db_comm.run("CREATE TABLE IF NOT EXISTS commands (command text)");
 }
 
 exports.set = function(key, data, cb) {
@@ -91,11 +93,10 @@ exports.del = function(key, cb) {
 }
 
 exports.all = function(cb) {
- load(function(err) {
-   if (err) return cb(err);
-
-   cb && cb(null, db);
- })
+  load(function(err) {
+    if (err) return cb(err);
+    cb && cb(null, db);
+  })
 }
 
 // empties db and removes file

--- a/lib/agent/utils/storage.js
+++ b/lib/agent/utils/storage.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
 
 var db_path, db_type, db_comm;
 
-var db_commands = {
+var queries = {
   CREATE: function(type) {return "CREATE TABLE IF NOT EXISTS " + type + " (" + singular(type) + " text)"},
   INSERT: function(type) {return "INSERT INTO " + type + " VALUES (?)"},
   SELECT: function(type) {return "SELECT * FROM " + type},
@@ -26,7 +26,7 @@ var load = function(type, cb) {
     return cb(new Error('Invalid path'), null);
   }
 
-  db_comm.all(db_commands.SELECT(type), function(err, rows) {
+  db_comm.all(queries.SELECT(type), function(err, rows) {
     if (err) {
       if (err.code != 'ENOENT')
         return cb(err, null);
@@ -39,7 +39,8 @@ var load = function(type, cb) {
       var db1 = {};
       for (var i = 0; i < rows.length; i++) {
         var value = JSON.parse(new Buffer(rows[i][singular(type)], 'base64').toString());
-        for (var attr in value) { db1[attr] = value[attr] }
+        var key = Object.keys(value)[0];
+        db1[key] = value[key];
       }
       db = db1;
     } catch(e) {
@@ -56,7 +57,7 @@ var remove = function(type, cb) {
     return cb();
   }
 
-  db_comm.run(db_commands.DELETE(type), function(err) {
+  db_comm.run(queries.DELETE(type), function(err) {
     var e = err && err.code != 'ENOENT' ? err : null;
     return cb && cb(e);
   })
@@ -69,8 +70,8 @@ var save = function(type, db, cb) {
   }
 
   remove(type, function() {
-    db_comm.run(db_commands.CREATE(type), function(err) {
-      var stmt = db_comm.prepare(db_commands.INSERT(type)); 
+    db_comm.run(queries.CREATE(type), function(err) {
+      var stmt = db_comm.prepare(queries.INSERT(type)); 
       for (var k in db) {
         var db1 = {};
         db1[k] = db[k];
@@ -86,7 +87,7 @@ var save = function(type, db, cb) {
 
 exports.init = function(type, path, cb) {
   db_comm = new sqlite3.Database(path);
-  db_comm.run(db_commands.CREATE(type), function(err) {
+  db_comm.run(queries.CREATE(type), function(err) {
     db_path = path;
     return cb && cb(err);
   });


### PR DESCRIPTION
In this PR the command storage logic is modified to use sqlite, creating a special table for pending commands and another for uploading files.
The goal of these changes is to avoid the previous corruption of the original command file when the pc is shutted down in the hard way, and keep a most organized set of commands in the file.