### PR TITLE
Files upload resuming

### DIFF
--- a/lib/agent/actions/fileretrieval/index.js
+++ b/lib/agent/actions/fileretrieval/index.js
@@ -7,20 +7,28 @@
 // GPLv3 Licensed
 //////////////////////////////////////////
 
-var fs           = require('fs'),
-    path         = require('path'),
-    mime         = require('mime'),
-    common       = require('./../../common'),
-    needle       = require('needle'),
-    join         = require('path').join,
-    files        = require('./storage'),
-    Emitter      = require('events').EventEmitter;
+var fs          = require('fs'),
+    path        = require('path'),
+    mime        = require('mime'),
+    common      = require('./../../common'),
+    needle      = require('needle'),
+    join        = require('path').join,
+    files       = require('./storage'),
+    needle      = require('needle'),
+    Emitter     = require('events').EventEmitter;
 
 var system      = common.system,
     run_as_user = common.system.run_as_user,
     node_bin    = path.join(system.paths.current, 'bin', 'node'),
     os_name     = process.platform.replace('darwin', 'mac').replace('win32', 'windows'),
     logger      = common.logger;
+
+var config   = common.config,
+    protocol = config._values['control-panel'].protocol,
+    host     = config._values['control-panel'].host,
+    url      = protocol + '://' + host;
+
+var UPLOAD_SERVER = url + '/upload/upload';
 
 var em,
     cp;
@@ -30,14 +38,8 @@ var path_arg,
 
 // check_pending_files is used to resume any files that might been pending. It's called from
 // filesagent/providers/network.
-exports.check_pending_files = function() {
-  files.run_stored();
-}
 
-exports.start = function(options, cb) {
-  if (!options.resumable) {
-    options.resumable = false;
-  }
+var retrieve_file_as_user = function(options, cb) {
   if (os_name == 'windows') {
     path_arg = path.resolve(options.path);
     name_arg = path.resolve(options.name);
@@ -49,14 +51,11 @@ exports.start = function(options, cb) {
     user: options.user,
     bin: node_bin,
     type: 'exec',
-    args: [path.join(__dirname, 'upload.js'), path_arg, options.user, name_arg, options.size, options.file_id, options.resumable, options.port],
+    args: [path.join(__dirname, 'upload.js'), path_arg, options.user, name_arg, options.size, options.file_id, options.total, options.port],
     opts: {
       env: process.env
     }
   };
-  em = em || new Emitter();
-
-  files.store(options.file_id, options.path, options.size, options.user, options.name);
 
   run_as_user(opts, function(err, out) {
     if (err) {
@@ -64,10 +63,73 @@ exports.start = function(options, cb) {
       return;
     }
     logger.info("Ran as user: " + out);
-    if (out.indexOf("File succesfuly uploaded") != -1){
+    if (out.indexOf("File succesfuly uploaded") != -1) {
       files.del(options.file_id);
     }
+    if (out.includes("EPIPE") {
+      files.update(options.file_id, options.path, options.size, options.user, options.name, options.resumable, function(err) {
+        if (err) logger.error("Database update error");
+        logger.info("Resume file option activated for ID: " + options.file_id);
+      });
+    }
   });
+
+}
+
+exports.check_pending_files = function() {
+  files.run_stored();
+}
+
+exports.start = function(options, cb) {
+  files.exist(options.file_id, function(err, exist) {
+    if (!exist) {
+      options.resumable = false;
+      options.total = 0;
+      files.store(options.file_id, options.path, options.size, options.user, options.name, options.resumable);
+      retrieve_file_as_user(options);
+
+    } else {
+      setTimeout(function() {
+        if (options.resumable) {
+          var url = UPLOAD_SERVER + '?uploadID=' + options.file_id;
+          // Make a call to get the last byte processed by the upload server
+          // in order to resume the upload from that position.
+          needle.request('get', url, null, function(err, res) {
+            if (err) {
+              console.log(err);
+              return;
+            }
+            if (res.statusCode == 404) {
+              files.del(options.file_id);
+              return;
+            }
+            var data = JSON.parse(res.body);
+            var file_status = JSON.parse(res.body).Status
+            options.total = data.Total;
+
+            if (file_status == 0) {
+              files.update(options.file_id, options.path, options.size, options.user, options.name, options.resumable, function(err) {
+                if (err) logger.error("Database update error");
+                logger.info("Resume file option deactivated for ID: " + options.file_id);
+                retrieve_file_as_user(options);
+              });
+
+            } else {
+              if (file_status == 1) logger.debug("File already uploaded, deleting from db...")
+              files.del(options.file_id);
+              return;
+            }
+          })
+        } else {
+          // Files exists in db but the resumable option is false... delete it.
+          files.del(options.file_id);
+        }
+      }, 2000);
+    }
+  })
+
+  em = em || new Emitter();
+
   if (cb) cb(null, em);
   em.emit('end');
 }

--- a/lib/agent/actions/fileretrieval/index.js
+++ b/lib/agent/actions/fileretrieval/index.js
@@ -65,15 +65,15 @@ var retrieve_file_as_user = function(options, cb) {
     logger.info("Ran as user: " + out);
     if (out.indexOf("File succesfuly uploaded") != -1) {
       files.del(options.file_id);
+      return;
     }
-    if (out.includes("EPIPE")) {
+    if (out.includes("EPIPE") || out.includes("EACCES")) {
       files.update(options.file_id, options.path, options.size, options.user, options.name, options.resumable, function(err) {
         if (err) logger.error("Database update error");
         logger.info("Resume file option activated for ID: " + options.file_id);
       });
     }
   });
-
 }
 
 exports.check_pending_files = function() {
@@ -81,50 +81,51 @@ exports.check_pending_files = function() {
 }
 
 exports.start = function(options, cb) {
-  files.exist(options.file_id, function(err, exist) {
-    if (!exist) {
-      options.resumable = false;
-      options.total = 0;
-      files.store(options.file_id, options.path, options.size, options.user, options.name, options.resumable);
-      retrieve_file_as_user(options);
+  
+  var url = UPLOAD_SERVER + '?uploadID=' + options.file_id;
+  // Make a call to get the last byte processed by the upload server
+  // in order to resume the upload from that position.
+  needle.request('get', url, null, function(err, res) {
+    if (err) {
+      console.log(err);
+      return;
+    }
+    if (res.statusCode == 404) {
+      files.del(options.file_id);
+      return;
+    }
+    var data = JSON.parse(res.body);
+    var file_status = JSON.parse(res.body).Status
+    options.total = data.Total;
 
-    } else {
-      setTimeout(function() {
-        if (options.resumable) {
-          var url = UPLOAD_SERVER + '?uploadID=' + options.file_id;
-          // Make a call to get the last byte processed by the upload server
-          // in order to resume the upload from that position.
-          needle.request('get', url, null, function(err, res) {
-            if (err) {
-              console.log(err);
-              return;
-            }
-            if (res.statusCode == 404) {
-              files.del(options.file_id);
-              return;
-            }
-            var data = JSON.parse(res.body);
-            var file_status = JSON.parse(res.body).Status
-            options.total = data.Total;
+    if (file_status == 0 || file_status == 4) { // File in progress(0) or Pending(4)  
+      files.exist(options.file_id, function(err, exist) {
+        if (!exist) {
+          options.resumable = false;
+          options.total = 0;
+          files.store(options.file_id, options.path, options.size, options.user, options.name, options.resumable);
+          retrieve_file_as_user(options);
 
-            if (file_status == 0) {
+        } else {
+          setTimeout(function() {
+            if (options.resumable) {
               files.update(options.file_id, options.path, options.size, options.user, options.name, options.resumable, function(err) {
                 if (err) logger.error("Database update error");
                 logger.info("Resume file option deactivated for ID: " + options.file_id);
                 retrieve_file_as_user(options);
               });
-
-            } else {
-              if (file_status == 1) logger.debug("File already uploaded, deleting from db...")
-              files.del(options.file_id);
-              return;
             }
-          })
-        } else {
-          // Files exists in db but the resumable option is false... delete it.
-          files.del(options.file_id);
+          }, 2000);
         }
-      }, 2000);
+      })
+
+    } else {
+      if (file_status == 1) 
+        logger.debug("File already uploaded, deleting from db...");
+      else 
+        logger.debug("File cancelled or with an error, deleting from db...");
+      files.del(options.file_id);
+      return;
     }
   })
 

--- a/lib/agent/actions/fileretrieval/index.js
+++ b/lib/agent/actions/fileretrieval/index.js
@@ -66,7 +66,7 @@ var retrieve_file_as_user = function(options, cb) {
     if (out.indexOf("File succesfuly uploaded") != -1) {
       files.del(options.file_id);
     }
-    if (out.includes("EPIPE") {
+    if (out.includes("EPIPE")) {
       files.update(options.file_id, options.path, options.size, options.user, options.name, options.resumable, function(err) {
         if (err) logger.error("Database update error");
         logger.info("Resume file option activated for ID: " + options.file_id);

--- a/lib/agent/actions/fileretrieval/storage.js
+++ b/lib/agent/actions/fileretrieval/storage.js
@@ -15,25 +15,61 @@ var exist = function(id, cb) {
     if (err)
       return err.message;
     if (files[key])
-      return cb(true);
-    return cb(false);
+      return cb(null, true);
+    return cb(null, false);
   });
 }
 
-exports.store = function(id, path, size, user, name) {
-  exist(id, function(cb) {
-    if (cb == false) {
+exports.store = function(id, path, size, user, name, resumable) {
+  exist(id, function(err, out) {
+    if (out == false) {
       logger.debug('Storing file_id in DB: ' + id);
       var opts = {
         path: path,
         size: size,
         user: user,
-        name: name
+        name: name,
+        resumable: false
       }
       var key = ['file', id].join('-');
       storage.set(key, opts);
     }
   });
+}
+
+exports.update = function(id, path, size, user, name, resumable, cb) {
+  var key = ["file", id].join("-");
+
+  var file_del,
+      file_add,
+      obj_del = {},
+      obj_add = {},
+      to_delete,
+      to_add;
+
+  file_del = {
+    "path": path,
+    "size": size,
+    "user": user,
+    "name": name,
+    "resumable": resumable
+  }
+
+  file_add = {
+    "path": path,
+    "size": size,
+    "user": user,
+    "name": name,
+    "resumable": !resumable
+  }
+
+  obj_del[key] = file_del;
+  obj_add[key] = file_add;
+
+  to_delete = new Buffer(JSON.stringify(obj_del, null, 0)).toString('base64');
+  to_add    = new Buffer(JSON.stringify(obj_add, null, 0)).toString('base64');
+
+  storage.update(key, to_delete, to_add, cb);
 }
 
 exports.del = function(id) {
@@ -54,14 +90,16 @@ exports.run_stored = function(cb) {
 
     for (key in files) {
       var opts = {
-        path: files[key].path,
-        user: files[key].user,
-        name: files[key].name,
-        size: files[key].size,
-        file_id: key.substring(5, key.length),
-        resumable: true
+        path:      files[key].path,
+        user:      files[key].user,
+        name:      files[key].name,
+        size:      files[key].size,
+        file_id:   key.substring(5, key.length),
+        resumable: files[key].resumable
       }
       fileretrieval.start(opts, cb);
     }
   })
 }
+
+exports.exist = exist;

--- a/lib/agent/actions/fileretrieval/upload.js
+++ b/lib/agent/actions/fileretrieval/upload.js
@@ -89,6 +89,7 @@ function upload_file(file, buf, cb) {
 
   needle.post(url, buf, options, function(err, res) {
     if (err) {
+      console.log(err);
       return cb(err);
     }
     var out = res.statusCode;

--- a/lib/agent/actions/fileretrieval/upload.js
+++ b/lib/agent/actions/fileretrieval/upload.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-var fs           = require('fs'),
-    path         = require('path'),
-    mime         = require('mime'),
-    common       = require('./../../common'),
-    needle       = require('needle');
+var fs       = require('fs'),
+    path     = require('path'),
+    mime     = require('mime'),
+    common   = require('./../../common'),
+    needle   = require('needle');
 
-var config     = common.config,
-    protocol   = config._values['control-panel'].protocol,
-    host       = config._values['control-panel'].host,
-    url        = protocol + '://' + host;
+var config   = common.config,
+    protocol = config._values['control-panel'].protocol,
+    host     = config._values['control-panel'].host,
+    url      = protocol + '://' + host;
 
 var UPLOAD_SERVER    = url + '/upload/upload',
     RESUMABLE_HEADER = 'X-Prey-Upload-Resumable',
@@ -21,19 +21,19 @@ var PATH    = 2,
     NAME    = 4,
     SIZE    = 5,
     FILE_ID = 6,
-    RESUME  = 7,
+    TOTAL   = 7,
     PORT    = 8;
 
 function main() {
   var argv = process.argv;
   var options = {
-      path: argv[PATH],
-      user: argv[USER],
-      name: argv[NAME],
-      size: argv[SIZE],
+      path:    argv[PATH],
+      user:    argv[USER],
+      name:    argv[NAME],
+      size:    argv[SIZE],
       file_id: argv[FILE_ID],
-      resumable : argv[RESUME],
-      port: argv[PORT]
+      total:   argv[TOTAL],
+      port:    argv[PORT]
   }
   Main(options, function(err) {
     if (err) {
@@ -57,30 +57,7 @@ function Main(options, cb) {
     path: file_path,
     user: user,
     id: file_id,
-    size: file_size,
-    resumable: options.resumable
-  }
-  retrieve_file(file, cb);
-}
-
-function retrieve_file(file, cb) {
-  if (file.resumable == 'true') {
-    console.log("Resumable file:", file.id);
-    var url = UPLOAD_SERVER + '?uploadID=' + file.id;
-    // Make a call to get the last byte processed by the upload server
-    // in order to resume the upload from that position.
-    needle.request('get', url, null, function(err, res) {
-      if (err) {
-        console.log(err);
-        cb(err);
-        return;
-      }
-      var data = JSON.parse(res.body);
-
-      file.total = data.Total;
-      get_file(file, cb);
-    })
-    return;
+    size: file_size
   }
   get_file(file, cb);
 }
@@ -112,9 +89,7 @@ function upload_file(file, buf, cb) {
 
   needle.post(url, buf, options, function(err, res) {
     if (err) {
-      console.log(err);
-      cb(err);
-      return;
+      return cb(err);
     }
     var out = res.statusCode;
     if (out !== 200 && out !== 201) {

--- a/lib/agent/actions/fileretrieval/upload.js
+++ b/lib/agent/actions/fileretrieval/upload.js
@@ -90,7 +90,8 @@ function upload_file(file, buf, cb) {
   needle.post(url, buf, options, function(err, res) {
     if (err) {
       console.log(err);
-      return cb(err);
+      cb(err);
+      return;
     }
     var out = res.statusCode;
     if (out !== 200 && out !== 201) {


### PR DESCRIPTION
There was an issue for the file resuming after the client disconnection, after reconnecting if the request still exists the file upload continued so there's no need to use the logic implemented for resuming.

In this PR the file state is always verified and it takes action with that information, deleting the file db registry if the file it's completed or cancelled.