### PR TITLE
Signup mail maximum characters number change

### DIFF
--- a/lib/conf/gui/linux/prey-config.py
+++ b/lib/conf/gui/linux/prey-config.py
@@ -52,7 +52,7 @@ PACKAGE_INFO = json.loads(PACKAGE_JSON.read())
 VERSION = PACKAGE_INFO['version']
 
 PAGES = ['control_panel_options', 'new_user', 'existing_user', 'existing_device']
-EMAIL_REGEX = "^.+\\@(\\[?)[a-zA-Z0-9\\-\\.]+\\.([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$"
+EMAIL_REGEX = "^.+\\@(\\[?)[a-zA-Z0-9\\-\\.]+\\.([a-zA-Z]{2,7}|[0-9]{1,3})(\\]?)$"
 
 class PreyConfigurator(object):
 

--- a/lib/conf/gui/mac/PreyConfig.app/Contents/MacOS/prey-config.py
+++ b/lib/conf/gui/mac/PreyConfig.app/Contents/MacOS/prey-config.py
@@ -31,7 +31,7 @@ HEIGHT = 400
 WIDTH  = 500
 CENTER = WIDTH/2
 
-EMAIL_REGEX = "^.+\\@(\\[?)[a-zA-Z0-9\\-\\.]+\\.([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$"
+EMAIL_REGEX = "^.+\\@(\\[?)[a-zA-Z0-9\\-\\.]+\\.([a-zA-Z]{2,7}|[0-9]{1,3})(\\]?)$"
 
 TABS = ['welcome', 'new_user', 'existing_user', 'success']
 


### PR DESCRIPTION
Users with mails with too many characters after de '.' (Ex: hi@company.success) weren't able to signup to prey on mac and linux. This PR fixes that problem extending the maximum number of characters from 4 to 7.