### PR TITLE
Client update retry

### DIFF
--- a/lib/agent/utils/storage.js
+++ b/lib/agent/utils/storage.js
@@ -1,10 +1,10 @@
 var fs       = require('fs'),
     join     = require('path').join,
     sqlite3  = require('sqlite3').verbose(),
-    common   = require('./../common'),
+    config   = require('./../../system/paths').config,
     fileType = require('./../providers/file-type');
 
-var storage_path = join(common.system.paths.config, 'commands.db'),
+var storage_path = join(config, 'commands.db'),
     db_path, db_type, db_comm, tables = [];
 
 var SQLITE_ACCESS_ERR = "Access denied to commands database, must run agent as prey user"
@@ -24,6 +24,7 @@ var check_type = function(key, cb) {
   if (key.includes('start'))         return cb(null, 'commands');
   else if (key.includes('file-'))    return cb(null, 'files');
   else if (key.includes('geofence')) return cb(null, 'geofences');
+  else if (key.includes('version'))  return cb(null, 'versions');
   else return cb(new Error("Not an allowed type of key"))
 }
 

--- a/lib/agent/utils/storage.js
+++ b/lib/agent/utils/storage.js
@@ -1,10 +1,10 @@
 var fs       = require('fs'),
     join     = require('path').join,
     sqlite3  = require('sqlite3').verbose(),
-    config   = require('./../../system/paths').config,
+    common   = require('./../common'),
     fileType = require('./../providers/file-type');
 
-var storage_path = join(config, 'commands.db'),
+var storage_path = join(common.system.paths.config, 'commands.db'),
     db_path, db_type, db_comm, tables = [];
 
 var SQLITE_ACCESS_ERR = "Access denied to commands database, must run agent as prey user"
@@ -24,7 +24,6 @@ var check_type = function(key, cb) {
   if (key.includes('start'))         return cb(null, 'commands');
   else if (key.includes('file-'))    return cb(null, 'files');
   else if (key.includes('geofence')) return cb(null, 'geofences');
-  else if (key.includes('version'))  return cb(null, 'versions');
   else return cb(new Error("Not an allowed type of key"))
 }
 

--- a/lib/conf/install.js
+++ b/lib/conf/install.js
@@ -25,7 +25,7 @@ var activate_new_version = function(version, cb) {
 
   if (process.platform == 'win32') {
     var bin  = join(version_path, 'bin', 'node.exe');
-    // var args = [join('lib', 'conf', 'cli.js')].concat(args);
+    args = [join('lib', 'conf', 'cli.js')].concat(args);
   } else {
     var bin  = join(version_path, 'bin', paths.bin);
   }
@@ -38,17 +38,17 @@ var activate_new_version = function(version, cb) {
           var data = {
             name: 'device_client_updated',
             info: {
-              status: 'success',
+              status:  'success',
               old_ver: res.from,
               new_ver: res.to,
-              ip: res.public_ip,
+              ip:      res.public_ip,
               country: res.country,
-              arch: arch,
-              os: os_name
+              arch:    arch,
+              os:      os_name
             }
           }
           api.push['event'](data);
-          var key = ['version', ver].join('-');
+          var key = ['version', res.to].join('-');
 
           // After the upgrade process is successfuly done the registry is deleted
           storage.del(key, function(err) {

--- a/lib/conf/install.js
+++ b/lib/conf/install.js
@@ -26,7 +26,31 @@ var activate_new_version = function(version, cb) {
   }
 
   run_synced(bin, args, opts, function(err, code) {
-    if (!err && code === 0) return cb();
+    if (!err && code === 0) {
+      var api  = require('./../agent/plugins/control-panel/api'),
+          keys = require('./../agent/plugins/control-panel/api/keys'),
+
+      shared.keys.verify_current(function(err) {
+        if (err) return cb();
+        package.get_stable_version(function(err, ver) {
+          var data = {
+            name: 'device_client_updated',
+            info: {
+              status: 'success',
+              version: ver
+            }
+          }
+          api.push['event'](data)
+
+          var key = ['version', ver].join('-');
+          storage.del(key, function(err) {
+            if (err) shared.log("Error deleting update attempts registry" + err);
+            shared.log("Update attempts registry deleted");
+          });
+        });
+      });
+      return cb();
+    }
 
     shared.log('Failed. Rolling back!');
 

--- a/lib/conf/install.js
+++ b/lib/conf/install.js
@@ -6,7 +6,12 @@ var fs         = require('fs'),
     package    = common.package,
     paths      = system.paths,
     run_synced = require('./utils/run_synced'),
-    shared     = require('./shared');
+    shared     = require('./shared'),
+    storage    = require('./../agent/utils/storage');
+    api        = require('./../agent/plugins/control-panel/api'),
+    keys       = api.keys;
+    os_name    = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
+    arch       = process.arch == 'x64' ? 'x64' : 'x86';
 
 // calls 'prey config activate' on the new installation,
 // so that it performs the activation using its own paths and logic.
@@ -20,35 +25,38 @@ var activate_new_version = function(version, cb) {
 
   if (process.platform == 'win32') {
     var bin  = join(version_path, 'bin', 'node.exe');
-    args     = [join('lib', 'conf', 'cli.js')].concat(args);
+    // var args = [join('lib', 'conf', 'cli.js')].concat(args);
   } else {
     var bin  = join(version_path, 'bin', paths.bin);
   }
 
   run_synced(bin, args, opts, function(err, code) {
     if (!err && code === 0) {
-      var api  = require('./../agent/plugins/control-panel/api'),
-          keys = require('./../agent/plugins/control-panel/api/keys'),
-
       shared.keys.verify_current(function(err) {
         if (err) return cb();
-        package.get_stable_version(function(err, ver) {
+        package.get_update_data(function(res) {
           var data = {
             name: 'device_client_updated',
             info: {
               status: 'success',
-              version: ver
+              old_ver: res.from,
+              new_ver: res.to,
+              ip: res.public_ip,
+              country: res.country,
+              arch: arch,
+              os: os_name
             }
           }
-          api.push['event'](data)
-
+          api.push['event'](data);
           var key = ['version', ver].join('-');
+
+          // After the upgrade process is successfuly done the registry is deleted
           storage.del(key, function(err) {
             if (err) shared.log("Error deleting update attempts registry" + err);
-            shared.log("Update attempts registry deleted");
           });
         });
       });
+
       return cb();
     }
 

--- a/lib/package.js
+++ b/lib/package.js
@@ -8,6 +8,7 @@ var fs              = require('fs'),
     storage         = require('./agent/utils/storage');
     is_greater_than = require('./agent/helpers').is_greater_than,
     os_name         = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
+    arch            = process.arch == 'x64' ? 'x64' : 'x86',
     tmpdir          = os_name == 'windows' ? process.env.WINDIR + '\\Temp' : '/tmp';
 
 var delayed         = whenever('buckle');
@@ -86,6 +87,96 @@ var move = function(from, to, cb) {
   like_a_boss(1);
 }
 
+// Update local update attemps db until the maximum number is reached, after that there's not gonna be
+// more update attemps and the user is gonna be notified.
+var update_attempts = function(version, cb) {
+
+  var exist = function(db) {
+    var key = ['version', version].join('-');
+    if (db[key]) {
+      return true;
+    }
+    return false;
+  }
+
+  var update_versions = function(version, attempt_del, notif_add, cb) {
+    var key = ["version", version].join("-"),
+        attempt_add = attempt_del,
+        notif_del = notif_add;
+
+    var version_del,
+        version_add,
+        obj_del = {},
+        obj_add = {};
+
+    if (notif_add) notif_del = !notif_add;
+    else attempt_add = attempt_del + 1;
+
+    version_del = { "version": version, "attempts": attempt_del, "notified": notif_del };
+    version_add = { "version": version, "attempts": attempt_add, "notified": notif_add };
+
+    obj_del[key] = version_del;
+    obj_add[key] = version_add;
+
+    storage.update(key, obj_del, obj_add, cb);
+  }
+
+  storage.all('versions', function(err, db) {
+    if (err) return cb(new Error("Unable to load local database, update cancelled"));
+
+    var count = Object.keys(db).length;
+    if (count > 0 && exist) {
+      var key     = ['version', version].join('-'),
+          attempt = db[key].attempts;
+
+      if (db[key].attempts < MAX_UPDATE_ATTEMPS) {
+        // Number of attempts ++
+        update_versions(version, attempt, false, function(err) {
+          if (err) return cb(new Error("Unable to update local database, update cancelled"));
+          cb(null, true);
+        });
+      } else {
+        if (!db[key].notified) {
+          // Send the event when the maximum update attemps are reached
+          package.get_update_data(function(res) {
+            var api = require('./agent/plugins/control-panel/api');
+            var data = {
+              name: 'device_client_updated',
+              info: {
+                status: 'failed',
+                old_ver: res.from,
+                new_ver: res.to,
+                ip: res.public_ip,
+                country: res.country,
+                arch: arch,
+                os: os_name
+              }
+            }
+            api.push['event'](data, {}, function(err, res) {
+              if (err) log("Error sending the fail upgrade event");
+              if (res.statusCode == 200) {
+                log("Notifying update error to user");
+
+                update_versions(version, attempt, true, function(err) {
+                  if (err) log("Error updating notification status");
+                });
+              }
+            });
+          });
+        }
+        cb(null, false);
+      }
+    } else {
+      // Set the new client version attempts in the local database
+      var key = ['version', version].join('-');
+      storage.set(key, {version: version, attempts: 1, notified: false}, function(err) {
+        if (err) return cb(new Error("Couldn't open local database, update cancelled"));
+        cb(null, true)
+      })
+    }
+  })
+}
+
 /////////////////////////////////////////////////////////
 // releases module
 
@@ -113,6 +204,7 @@ releases.get_edge_version = function(cb) {
 }
 
 releases.download = function(url, cb) {
+  // var file = system.tempfile_path(path.basename(url));
   var file = path.join(tmpdir, path.basename(url));
 
   if (fs.existsSync(file)) {
@@ -121,7 +213,6 @@ releases.download = function(url, cb) {
   }
 
   log('Downloading package: ' + url);
-  // var file = system.tempfile_path(path.basename(url));
 
   needle.get(url, { output: file }, function(err, resp, data) {
 
@@ -168,8 +259,7 @@ releases.verify_checksum = function(version, filename, file, cb) {
 
 releases.download_verify = function(version, cb) {
 
-  var arch      = process.arch == 'x64' ? 'x64' : 'x86',
-      release   = ['prey', os_name, version, arch].join('-') + package_format,
+  var release   = ['prey', os_name, version, arch].join('-') + package_format,
       url       = releases_url + version + '/' + release;
 
   releases.download(url, function(err, file) {
@@ -193,7 +283,26 @@ releases.download_verify = function(version, cb) {
 
 var package = {};
 
-package.get_stable_version = releases.get_stable_version;
+// called from here and lib/conf/install when the update process failed or succeeded respectively
+package.get_update_data = function(cb) {
+  var common = require('./common'),
+      data   = {from: null, to: null, public_ip: null, country: null};
+
+  data.from = common.version;
+  releases.get_stable_version(function(err, ver) {
+    if (err) log("Unable to get last client version");
+    else data.to = ver;
+    needle.get('http://ipinfo.io/geo', function(err, resp, body) {
+      if (err || !body) {
+        log("Unable to get geolocation info");
+      } else {
+        data.public_ip = body.ip;
+        data.country   = body.country;
+      }
+      cb(data);
+    })
+  });
+}
 
 // called from lib/agent/updater to see whether to launch the 'config upgrade' process
 package.new_version_available = function(branch, current, cb) {
@@ -225,111 +334,22 @@ package.get_latest = function(branch, current_version, dest, cb) {
   });
 };
 
-package.update_attempts = function(version, cb) {
-  
-  var exist = function(db) {
-    var key = ['version', version].join('-');
-    if (db[key]) {
-      return true;
-    }
-    return false;
-  }
-
-  var update_versions = function(version, attempt_del, notif_add, cb) {
-    var key = ["version", version].join("-"),
-        attempt_add = attempt_del,
-        notif_del = notif_add;
-
-    var version_del,
-        version_add,
-        obj_del = {},
-        obj_add = {},
-        to_delete,
-        to_add;
-
-    if (notif_add) notif_del = !notif_add;
-    else attempt_add = attempt_del + 1;
-
-    version_del = {
-      "version": version,
-      "attempts": attempt_del,
-      "notified": notif_del
-    }
-    version_add = {
-      "version": version,
-      "attempts": attempt_add,
-      "notified": notif_add
-    }
-
-    obj_del[key] = version_del;
-    obj_add[key] = version_add;
-
-    to_delete = new Buffer(JSON.stringify(obj_del, null, 0)).toString('base64');
-    to_add    = new Buffer(JSON.stringify(obj_add, null, 0)).toString('base64');
-
-    storage.update(key, to_delete, to_add, cb);
-  }
-
-  storage.all('versions', function(err, db) {
-    if (err) return cb("There was a problem loading local database, update cancelled");
-
-    var count = Object.keys(db).length;
-    
-    if (count > 0 && exist) {
-      var key = ['version', version].join('-');
-      var attempt = db[key].attempts;
-
-      if (db[key].attempts < MAX_UPDATE_ATTEMPS) {
-        update_versions(version, attempt, false, function(err) {
-          if (err) return cb("There was a problem updating local database, update cancelled");
-          cb(null, true);
-        });
-      } else {
-        if (!db[key].notified) {
-          releases.get_stable_version(function(err, ver) {
-            if (err) var ver = null;
-            var api = require('./agent/plugins/control-panel/api'),
-            var data = {
-              name: 'device_client_updated',
-              info: {
-                status: 'failed',
-                version: ver
-              }
-            }
-            api.push['event'](data);
-            update_versions(version, attempt, true, function() {
-              log("Notifying update error to user");
-            })
-          })
-        } else {
-          log("User already notified");
-        }
-        cb(null, false);
-      }
-    } else {
-      var key = ['version', version].join('-');
-      storage.set(key, {version: version, attempts: 1, notified: false}, function(err) {
-        if (err) return cb("There was a problem with local database, update cancelled");
-        cb(null, true)
-      })
-    }
-  })
-}
-
 // called from lib/conf/install when a specific version is passed, e.g. 'config upgrade 1.2.3'
 package.get_version = function(version, dest, cb) {
   var keys   = require('./agent/plugins/control-panel/api/keys'),
       shared = require('./conf/shared');
 
+  // The upgrade process it's gonna start only when the account is verified.
   shared.keys.verify_current(function(err) {
-    if (err) return cb(new Error("Missing user credencials, update cancelled"));
+    if (err) return cb(new Error("Missing user credencials, update cancelled for now"));
 
-    package.update_attempts(version, function(err, keys) {
-      if (err) return cb(new Error(err));
-      if (keys) {
+    update_attempts(version, function(err, update) {
+      if (err) return cb(err);
+      if (update) {
         var final_path = path.join(dest, version);
-        if (fs.existsSync(final_path))
+        if (fs.existsSync(final_path)) {
           return cb(new Error('v' + version + ' already installed in ' + dest))
+        }
 
         log('Fetching version ' + version);
         releases.download_verify(version, function(err, file) {
@@ -340,7 +360,7 @@ package.get_version = function(version, dest, cb) {
           });
         });
       } else {
-        return cb(new Error("Maximum number of update attempts reached");
+        return cb(new Error("Maximum number of upgrade attempts reached"));
       }
     });
   });

--- a/lib/package.js
+++ b/lib/package.js
@@ -5,6 +5,7 @@ var fs              = require('fs'),
     rmdir           = require('rimraf'),
     cp              = require('child_process'),
     whenever        = require('whenever'),
+    storage         = require('./agent/utils/storage');
     is_greater_than = require('./agent/helpers').is_greater_than,
     os_name         = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
     tmpdir          = os_name == 'windows' ? process.env.WINDIR + '\\Temp' : '/tmp';
@@ -18,6 +19,8 @@ var releases_host   = 'https://downloads.preyproject.com',
     latest_text     = 'latest.txt',
     checksums       = 'shasums.json',
     package_format  = '.zip';
+
+var MAX_UPDATE_ATTEMPS = 3;
 
 /////////////////////////////////////////////////////////
 // helpers
@@ -110,9 +113,15 @@ releases.get_edge_version = function(cb) {
 }
 
 releases.download = function(url, cb) {
+  var file = path.join(tmpdir, path.basename(url));
+
+  if (fs.existsSync(file)) {
+    log('Package already downloaded, moving on...')
+    return cb(null, file);
+  }
+
   log('Downloading package: ' + url);
   // var file = system.tempfile_path(path.basename(url));
-  var file = path.join(tmpdir, path.basename(url));
 
   needle.get(url, { output: file }, function(err, resp, data) {
 
@@ -184,6 +193,8 @@ releases.download_verify = function(version, cb) {
 
 var package = {};
 
+package.get_stable_version = releases.get_stable_version;
+
 // called from lib/agent/updater to see whether to launch the 'config upgrade' process
 package.new_version_available = function(branch, current, cb) {
   var method = 'get_' + branch + '_version';
@@ -214,21 +225,123 @@ package.get_latest = function(branch, current_version, dest, cb) {
   });
 };
 
+package.update_attempts = function(version, cb) {
+  
+  var exist = function(db) {
+    var key = ['version', version].join('-');
+    if (db[key]) {
+      return true;
+    }
+    return false;
+  }
+
+  var update_versions = function(version, attempt_del, notif_add, cb) {
+    var key = ["version", version].join("-"),
+        attempt_add = attempt_del,
+        notif_del = notif_add;
+
+    var version_del,
+        version_add,
+        obj_del = {},
+        obj_add = {},
+        to_delete,
+        to_add;
+
+    if (notif_add) notif_del = !notif_add;
+    else attempt_add = attempt_del + 1;
+
+    version_del = {
+      "version": version,
+      "attempts": attempt_del,
+      "notified": notif_del
+    }
+    version_add = {
+      "version": version,
+      "attempts": attempt_add,
+      "notified": notif_add
+    }
+
+    obj_del[key] = version_del;
+    obj_add[key] = version_add;
+
+    to_delete = new Buffer(JSON.stringify(obj_del, null, 0)).toString('base64');
+    to_add    = new Buffer(JSON.stringify(obj_add, null, 0)).toString('base64');
+
+    storage.update(key, to_delete, to_add, cb);
+  }
+
+  storage.all('versions', function(err, db) {
+    if (err) return cb("There was a problem loading local database, update cancelled");
+
+    var count = Object.keys(db).length;
+    
+    if (count > 0 && exist) {
+      var key = ['version', version].join('-');
+      var attempt = db[key].attempts;
+
+      if (db[key].attempts < MAX_UPDATE_ATTEMPS) {
+        update_versions(version, attempt, false, function(err) {
+          if (err) return cb("There was a problem updating local database, update cancelled");
+          cb(null, true);
+        });
+      } else {
+        if (!db[key].notified) {
+          releases.get_stable_version(function(err, ver) {
+            if (err) var ver = null;
+            var api = require('./agent/plugins/control-panel/api'),
+            var data = {
+              name: 'device_client_updated',
+              info: {
+                status: 'failed',
+                version: ver
+              }
+            }
+            api.push['event'](data);
+            update_versions(version, attempt, true, function() {
+              log("Notifying update error to user");
+            })
+          })
+        } else {
+          log("User already notified");
+        }
+        cb(null, false);
+      }
+    } else {
+      var key = ['version', version].join('-');
+      storage.set(key, {version: version, attempts: 1, notified: false}, function(err) {
+        if (err) return cb("There was a problem with local database, update cancelled");
+        cb(null, true)
+      })
+    }
+  })
+}
+
 // called from lib/conf/install when a specific version is passed, e.g. 'config upgrade 1.2.3'
 package.get_version = function(version, dest, cb) {
+  var keys   = require('./agent/plugins/control-panel/api/keys'),
+      shared = require('./conf/shared');
 
-  var final_path = path.join(dest, version);
-  if (fs.existsSync(final_path))
-    return cb(new Error('v' + version + ' already installed in ' + dest))
+  shared.keys.verify_current(function(err) {
+    if (err) return cb(new Error("Missing user credencials, update cancelled"));
 
-  log('Fetching version ' + version);
-  releases.download_verify(version, function(err, file) {
-    if (err) return cb(err);
+    package.update_attempts(version, function(err, keys) {
+      if (err) return cb(new Error(err));
+      if (keys) {
+        var final_path = path.join(dest, version);
+        if (fs.existsSync(final_path))
+          return cb(new Error('v' + version + ' already installed in ' + dest))
 
-    package.install(file, dest, function(err, installed_version) {
-      fs.unlink(file, function() {
-        cb(err, installed_version);
-      })
+        log('Fetching version ' + version);
+        releases.download_verify(version, function(err, file) {
+          if (err) return cb(err);
+
+          package.install(file, dest, function(err, installed_version) {
+            cb(err, installed_version);
+          });
+        });
+      } else {
+        return cb(new Error("Maximum number of update attempts reached");
+      }
     });
   });
 }

--- a/lib/package.js
+++ b/lib/package.js
@@ -143,13 +143,13 @@ var update_attempts = function(version, cb) {
             var data = {
               name: 'device_client_updated',
               info: {
-                status: 'failed',
+                status:  'failed',
                 old_ver: res.from,
                 new_ver: res.to,
-                ip: res.public_ip,
+                ip:      res.public_ip,
                 country: res.country,
-                arch: arch,
-                os: os_name
+                arch:    arch,
+                os:      os_name
               }
             }
             api.push['event'](data, {}, function(err, res) {


### PR DESCRIPTION
Upgrade logic modified:
- The download package is not gonna be deleted and it's gonna be used again when the retry occurs.
- After 3 upgrade failed attempts the client it's gonna send an event to the control panel and the client it's not gonna try to upgrade again.
- When the upgrade is succeeded the success event it's also sent.