### PR TITLE
Append to log file rather than truncating

### DIFF
--- a/lib/agent/common.js
+++ b/lib/agent/common.js
@@ -1,7 +1,9 @@
+
 var join        = require('path').join,
     common      = require(join(__dirname, '..', 'common')),
     program     = common.program,
-    paths       = common.system.paths;
+    paths       = common.system.paths,
+    fs          = require('fs');
 
 common.helpers  = require('./helpers');
 
@@ -9,6 +11,9 @@ var log_file    = (program.logfile || common.helpers.running_on_background())
                 ? (program.logfile || paths.log_file) : null;
 
 var log_level   = program.debug ? 'debug' : 'info';
-common.logger   = require('petit').new({ level: log_level, file: log_file });
+var log_stream  = fs.createWriteStream(log_file, {flags: 'a'});
+
+common.logger   = require('petit').new({ level: log_level,
+                                         stream: log_stream });
 
 module.exports  = common;


### PR DESCRIPTION
Throwing away logs by overwriting them on restart is a terrible thing
to do.

It's even more terrible for security products to do this.