### PR TITLE
Geofencing mac address check

### DIFF
--- a/lib/agent/actions/geofencing/storage.js
+++ b/lib/agent/actions/geofencing/storage.js
@@ -9,11 +9,8 @@ exports.store = function(geofence, cb) {
     name: geofence.name,
     state: geofence.state
   }
-  var key = ['geofence', opts.id].join('-'),
-      obj_add = {};
-
-  obj_add[key] = opts;
-  storage.set(key, obj_add, cb);
+  var key = ['geofence', opts.id].join('-');
+  storage.set(key, opts, cb);
 }
 
 exports.update = function(id, name, del, add, cb) {

--- a/lib/agent/triggers/geofencing/index.js
+++ b/lib/agent/triggers/geofencing/index.js
@@ -26,51 +26,33 @@
 //
 //////////////////////////////////////////
 
-var util    = require('util'),
-    Emitter = require('events').EventEmitter,
-    logger  = require('./../../common').logger.prefix('geofencing'),
-    geo     = require('./../../providers/geo'),
-    LatLon  = require('./lib/latlng'),
-    storage = require('./../../actions/geofencing/storage');
+var util        = require('util'),
+    Emitter     = require('events').EventEmitter,
+    os_name     = process.platform.replace('darwin', 'mac').replace('win32', 'windows'),
+    network     = require('./../../providers/network/' + os_name),
+    logger      = require('./../../common').logger.prefix('geofencing'),
+    geo         = require('./../../providers/geo'),
+    LatLon      = require('./lib/latlng'),
+    storage     = require('./../../actions/geofencing/storage'),
+    device_keys = require('./../../utils/keys-storage');
 
-var fences = {};
+var check_ap_mac,
+    current_mac,
+    fences = {},
+    last_location = {lat: 0.0, lng: 0.0, accuracy: 0, method: null};
 
-var location;
-var last_location = {lat: 0.0, lng: 0.0, accuracy: 0, method: null};
-
-var LocationTrigger = function() {
-  var self = this;
-  this.interval = this.interval || 1000 * 60 * 60 * 1; // one hour
-  
-  this.start = function(callback) {
-    function get_location() {
-      geo.get_location(function(err, coords) {
-        if (err) {
-          logger.error('There was a problem verifying location');
-          return callback();
-        }
+var checkLocation = function(cb) {
+  function get_location() {
+    geo.get_location(function(err, coords) {
+      if (err || coords.method != 'wifi') {
+        return cb(new Error("There was a problem verifying location"))
+      } else {
         last_location = coords;
-        callback();
-      });
-    }
-
-    function iterate_location() {
-      geo.get_location(function(err, coords) {
-        if (err) {
-          logger.error('There was a problem verifying location');
-        }
-        last_location = coords;
-      });
-    }
-
-    get_location();
-    this.loop = setInterval(iterate_location, this.interval);
-
+        return cb(null);
+      }
+    });
   }
-  this.stop = function(err) {
-    clearInterval(this.loop);
-    self.removeAllListeners();
-  }
+  get_location();
 }
 
 var GeofenceTrigger = function(options) {
@@ -94,7 +76,7 @@ var GeofenceTrigger = function(options) {
   this.start = function(callback) {
     var origin = {lat: self.lat, lng: self.lng};
 
-    function check_location() {
+    function check_geozones() {
       if (last_location) {
         logger.debug('Verifying geofence: ' + self.id + ', Radius: ' + self.radius);
         logger.debug("Current location: " + last_location.lat + "," + last_location.lng);
@@ -113,7 +95,7 @@ var GeofenceTrigger = function(options) {
             });
 
             if (self.state == 'inside' && self.direction !== 'in') {
-              logger.debug('Device left the geofence! Notifying')
+              logger.info('Device left the geofence ' + self.name + '! Notifying')
               self.emit('left_geofence', last_location);
             }
 
@@ -126,7 +108,7 @@ var GeofenceTrigger = function(options) {
             });
 
             if ((self.state == 'outside' && self.direction !== 'out') || self.state == null) {
-              logger.debug('Device got inside the geofence! Notifying')
+              logger.info('Device got inside the geofence ' + self.name + '! Notifying')
               self.emit('entered_geofence', last_location);
             }
 
@@ -137,20 +119,64 @@ var GeofenceTrigger = function(options) {
     }
 
     callback(null, self);
-    check_location(); // trigger immediately, then interval
-    this.loop = setInterval(check_location, this.interval);
-
+    check_geozones(); // trigger immediately, then interval
   };
 
   this.stop = function(err) {
-    clearInterval(this.loop);
     // self.emit('end', err);
     self.removeAllListeners();
   };
 
 };
 
-util.inherits(LocationTrigger, Emitter);
+var MacCheckTrigger = function() {
+  var self = this;
+  var loop;
+  var interval = 1000 * 60 * 3; // Check every 3 minutes
+
+  this.start = function(cb) {
+    function compare_mac() {
+      network.get_active_access_point_mac(function(err, out) {
+        if (err || !out) return cb(new Error('Unable to get the active access point mac address'));
+        current_mac = out.split("\n").slice(0, -1)[0];
+      
+        device_keys.get_stored('mac', function(err, stored_mac) {
+          if (err) return cb(err);
+          if (!stored_mac) {
+            checkLocation(function(err) {
+              if (err) return cb(err);
+              device_keys.store('mac', current_mac, function(err) {
+                if (err) return cb(err);
+                cb(null, true);
+              })
+            })
+          } else {
+            if (current_mac == stored_mac) {
+              return cb(null, false);  // Do nothing
+            } else {
+              checkLocation(function(err, coords) {
+                if (err) return cb(err);
+                device_keys.update('mac', stored_mac, current_mac, function(err) {
+                  if (err) return cb(err);
+                  cb(null, true);
+                })
+              })
+            }
+          }
+        })
+      })
+    }
+    compare_mac();
+    loop = setInterval(compare_mac, interval);
+  }
+
+  this.stop = function(err) {
+    clearInterval(loop);
+    self.removeAllListeners();
+  }
+}
+
+util.inherits(MacCheckTrigger, Emitter);
 util.inherits(GeofenceTrigger, Emitter);
 
 /////////////////////////////
@@ -166,13 +192,14 @@ function start(locations, callback) {
   // TODO @lemavri stop only fences missing from options.location that are already running
   stop();
 
-  if (location) {
-    location.stop();
+  if (check_ap_mac) {
+    check_ap_mac.stop();
   }
 
-  location = new LocationTrigger();
-  location.start(function() {
-
+  check_ap_mac = new MacCheckTrigger();
+  check_ap_mac.start(function(err, run) {
+    if (err) logger.error(err.message);
+    
     locations.forEach(function (location) {
       var opts = {
         id: location.id,
@@ -185,19 +212,20 @@ function start(locations, callback) {
         state: location.state
       };
 
-      if(fences[location.id]) {
+      if (fences[location.id]) {
         fences[location.id].stop();
       }
 
       fences[location.id] = new GeofenceTrigger(opts);
-      fences[location.id].start(callback);
+      if (!err && run) fences[location.id].start(callback);
+      else return callback(null, fences[location.id]);
     });
   });
 };
 
 function stop(cb) {
   // Called when geofence action receives empty array of geofences.
-  if (location) location.stop();
+  if (check_ap_mac) check_ap_mac.stop();
 
   if (Object.keys(fences).length) {
     Object.keys(fences).forEach(function(k) {

--- a/lib/agent/utils/keys-storage.js
+++ b/lib/agent/utils/keys-storage.js
@@ -1,0 +1,38 @@
+var storage  = require('./storage');
+
+function update(id, del, add, cb) {
+  var key = [id, 'key'].join('-');
+  var key_del, key_add,
+      obj_del = {}, obj_add = {};
+
+  key_del = { "value": del };
+  key_add = { "value": add };
+  obj_del[key] = key_del;
+  obj_add[key] = key_add;
+
+  storage.update(key, obj_del, obj_add, cb);
+}
+
+function store(id, current, cb) {
+  var key  = [id, 'key'].join('-'),
+      opts = { value: current };
+
+  storage.set(key, opts, cb);
+}
+
+function get_stored(id, cb) {
+  storage.all('keys', function(err, db) {
+    if (err || !db) return cb() && cb(err);
+    var key = [id, 'key'].join('-');
+
+    if (db[key]) {
+      return cb(null, db[key].value);
+    } else {
+      return cb(null, null);
+    }
+  })
+}
+
+exports.update     = update;
+exports.store      = store;
+exports.get_stored = get_stored;

--- a/lib/agent/utils/storage.js
+++ b/lib/agent/utils/storage.js
@@ -26,6 +26,7 @@ var check_type = function(key, cb) {
   else if (key.includes('file-'))    return cb(null, 'files');
   else if (key.includes('geofence')) return cb(null, 'geofences');
   else if (key.includes('version'))  return cb(null, 'versions');
+  else if (key.includes('key'))      return cb(null, 'keys');
   else return cb(new Error("Not an allowed type of key"))
 }
 


### PR DESCRIPTION
This PR introduces new logic for the location change detection used in geofencing.
When the wifi location succeeded the mac address it's saved in the local storage and when it detects a new mac address the registry it's updated. When the device it's connected to a new mac address the client looks for the location and checks if zones states changed and notifies if that's the case.
The mac address it's checked every 3 minutes.