### PR TITLE
Location fix for cyrillic alphabet

### DIFF
--- a/lib/agent/providers/network/windows.js
+++ b/lib/agent/providers/network/windows.js
@@ -80,10 +80,12 @@ exports.get_access_points_list = function(callback) {
     parser = 'netsh';
   }
 
-  exec(cmd, function(err, out) {
-    if (err) return done(err);
-    list = exports['parse_access_points_list_' + parser](out);
-    done();
+  exec('chcp 65001', function() {
+    exec(cmd, function(err, out) {
+      if (err) return done(err);
+      list = exports['parse_access_points_list_' + parser](out);
+      done();
+    })
   })
 
 };


### PR DESCRIPTION
The devices using cyrillic alphabet can't recognise the nearest access points because the command that get that info returns characters unrecognisable for the client.
This PR changes the charset before running the command.