### PR TITLE
Local database duplications fix

### DIFF
--- a/lib/agent/triggers/geofencing/index.js
+++ b/lib/agent/triggers/geofencing/index.js
@@ -92,27 +92,30 @@ var GeofenceTrigger = function(options) {
 
             storage.update(self.id, self.name, self.state, 'outside', function(err) {
               if (err) logger.error(err);
+              else {
+                if (self.state == 'inside' && self.direction !== 'in') {
+                  logger.info('Device left the geofence ' + self.name + '! Notifying')
+                  self.emit('left_geofence', last_location);
+                }
+
+                self.state = 'outside';
+              }
             });
 
-            if (self.state == 'inside' && self.direction !== 'in') {
-              logger.info('Device left the geofence ' + self.name + '! Notifying')
-              self.emit('left_geofence', last_location);
-            }
-
-            self.state = 'outside';
-            
           } else { // inside
 
             storage.update(self.id, self.name, self.state, 'inside', function(err) {
               if (err) logger.error(err);
+              else {
+                if ((self.state == 'outside' && self.direction !== 'out') || self.state == null) {
+                  logger.info('Device got inside the geofence ' + self.name + '! Notifying')
+                  self.emit('entered_geofence', last_location);
+                }
+
+                self.state = 'inside';
+              }
             });
 
-            if ((self.state == 'outside' && self.direction !== 'out') || self.state == null) {
-              logger.info('Device got inside the geofence ' + self.name + '! Notifying')
-              self.emit('entered_geofence', last_location);
-            }
-
-            self.state = 'inside';
           }
         } 
       } 

--- a/lib/agent/utils/storage.js
+++ b/lib/agent/utils/storage.js
@@ -74,14 +74,19 @@ var remove = function(type, cb) {
 }
 
 var save = function(type, add, cb) {
-  var stmt   = db_comm.prepare(queries.INSERT(type));
-  var to_add = new Buffer(JSON.stringify(add, null, 0)).toString('base64');
-  
-  stmt.run(to_add, function(err) {
-    var e = err && err.code == 'SQLITE_READONLY' ? SQLITE_ACCESS_ERR : err
-    stmt.finalize();
-    return cb && cb(e);
-  });
+  load(type, function(err, db) {
+    if (db[Object.keys(add)])
+      return cb(new Error("The registry already exists"));
+
+    var stmt   = db_comm.prepare(queries.INSERT(type));
+    var to_add = new Buffer(JSON.stringify(add, null, 0)).toString('base64');
+
+    stmt.run(to_add, function(err) {
+      var e = err && err.code == 'SQLITE_READONLY' ? SQLITE_ACCESS_ERR : err
+      stmt.finalize();
+      return cb && cb(e);
+    });
+  })
 }
 
 var drop = function(type, del, cb) {


### PR DESCRIPTION
Every time the client save a a command, geofence, file, etc, it checks if the key already exists before store it, doesn't save it if that's the case to prevent replication in the db.