### PR TITLE
Update success event modified to be sent after the client reloads

### DIFF
--- a/lib/agent/updater.js
+++ b/lib/agent/updater.js
@@ -92,11 +92,14 @@ var check_for_update = function(cb) {
 
   logger.debug('Checking for updates on ' + branch + ' branch...');
   common.package.new_version_available(branch, common.version, function(err, new_version) {
-    if (err || !new_version)
-      return cb && cb(err);
-
-    logger.notice('New version found: ' + new_version);
-    update_client(new_version, cb);
+    if (err || !new_version) {
+      common.package.check_update_success(common.version, function(err) {
+        return cb && cb(err);
+      })
+    } else {
+      logger.notice('New version found: ' + new_version);
+      update_client(new_version, cb);
+    }
   })
 }
 

--- a/lib/conf/install.js
+++ b/lib/conf/install.js
@@ -6,12 +6,7 @@ var fs         = require('fs'),
     package    = common.package,
     paths      = system.paths,
     run_synced = require('./utils/run_synced'),
-    shared     = require('./shared'),
-    storage    = require('./../agent/utils/storage');
-    api        = require('./../agent/plugins/control-panel/api'),
-    keys       = api.keys;
-    os_name    = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
-    arch       = process.arch == 'x64' ? 'x64' : 'x86';
+    shared     = require('./shared');
 
 // calls 'prey config activate' on the new installation,
 // so that it performs the activation using its own paths and logic.
@@ -25,40 +20,13 @@ var activate_new_version = function(version, cb) {
 
   if (process.platform == 'win32') {
     var bin  = join(version_path, 'bin', 'node.exe');
-    args = [join('lib', 'conf', 'cli.js')].concat(args);
+    args     = [join('lib', 'conf', 'cli.js')].concat(args);
   } else {
     var bin  = join(version_path, 'bin', paths.bin);
   }
 
   run_synced(bin, args, opts, function(err, code) {
-    if (!err && code === 0) {
-      shared.keys.verify_current(function(err) {
-        if (err) return cb();
-        package.get_update_data(function(res) {
-          var data = {
-            name: 'device_client_updated',
-            info: {
-              status:  'success',
-              old_ver: res.from,
-              new_ver: res.to,
-              ip:      res.public_ip,
-              country: res.country,
-              arch:    arch,
-              os:      os_name
-            }
-          }
-          api.push['event'](data);
-          var key = ['version', res.to].join('-');
-
-          // After the upgrade process is successfuly done the registry is deleted
-          storage.del(key, function(err) {
-            if (err) shared.log("Error deleting update attempts registry" + err);
-          });
-        });
-      });
-
-      return cb();
-    }
+    if (!err && code === 0) return cb();
 
     shared.log('Failed. Rolling back!');
 

--- a/lib/package.js
+++ b/lib/package.js
@@ -6,6 +6,7 @@ var fs              = require('fs'),
     cp              = require('child_process'),
     whenever        = require('whenever'),
     storage         = require('./agent/utils/storage');
+    device_keys     = require('./agent/utils/keys-storage');
     is_greater_than = require('./agent/helpers').is_greater_than,
     os_name         = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
     arch            = process.arch == 'x64' ? 'x64' : 'x86',
@@ -87,9 +88,62 @@ var move = function(from, to, cb) {
   like_a_boss(1);
 }
 
+var update_versions = function(old_version, new_version, attempt_del, notif_add, cb) {
+  var key = ["version", new_version].join("-"),
+      attempt_add = attempt_del,
+      notif_del = notif_add;
+
+  var version_del,
+      version_add,
+      obj_del = {},
+      obj_add = {};
+
+  if (notif_add) notif_del = !notif_add;
+  else attempt_add = attempt_del + 1;
+
+  version_del = { "from": old_version, "to": new_version, "attempts": attempt_del, "notified": notif_del };
+  version_add = { "from": old_version, "to": new_version, "attempts": attempt_add, "notified": notif_add };
+
+  obj_del[key] = version_del;
+  obj_add[key] = version_add;
+
+  storage.update(key, obj_del, obj_add, cb);
+}
+
+var send_update_event = function(status, old, cb) {
+  var keys   = require('./agent/plugins/control-panel/api/keys'),
+      shared = require('./conf/shared');
+  shared.keys.verify_current(function(err) {
+    package.get_update_data(function(res) {
+      var from = old || res.from;
+      var api = require('./agent/plugins/control-panel/api');
+      var data = {
+        name: 'device_client_updated',
+        info: {
+          status:  status,
+          old_ver: from,
+          new_ver: res.to,
+          ip:      res.public_ip,
+          country: res.country,
+          arch:    arch,
+          os:      os_name
+        }
+      }
+      api.push['event'](data, {}, function(err, res) {
+        if (err || res.statusCode != 200)
+          return cb(new Error("Error sending the upgrade event"));
+        else {
+          log("Sending update event to the control panel");
+          return cb(null);
+        }
+      });
+    });
+  });
+}
+
 // Update local update attemps db until the maximum number is reached, after that there's not gonna be
 // more update attemps and the user is gonna be notified.
-var update_attempts = function(version, cb) {
+var update_attempts = function(old_version, new_version, cb) {
 
   var exist = function(db) {
     var key = ['version', version].join('-');
@@ -99,33 +153,14 @@ var update_attempts = function(version, cb) {
     return false;
   }
 
-  var update_versions = function(version, attempt_del, notif_add, cb) {
-    var key = ["version", version].join("-"),
-        attempt_add = attempt_del,
-        notif_del = notif_add;
-
-    var version_del,
-        version_add,
-        obj_del = {},
-        obj_add = {};
-
-    if (notif_add) notif_del = !notif_add;
-    else attempt_add = attempt_del + 1;
-
-    version_del = { "version": version, "attempts": attempt_del, "notified": notif_del };
-    version_add = { "version": version, "attempts": attempt_add, "notified": notif_add };
-
-    obj_del[key] = version_del;
-    obj_add[key] = version_add;
-
-    storage.update(key, obj_del, obj_add, cb);
-  }
-
   var create_version = function(version, cb) {
     var key = ['version', version].join('-');
-    storage.set(key, {version: version, attempts: 1, notified: false}, function(err) {
-      if (err) return cb(new Error("Couldn't open local database, update cancelled"));
-      cb(null, true)
+    storage.clear('versions', function(err) {
+      if (err) return cb(new Error("Unable to edit local database, update cancelled"));
+      storage.set(key, {from: old_version, to: new_version, attempts: 1, notified: false}, function(err) {
+        if (err) return cb(new Error("Couldn't open local database, update cancelled"));
+        return cb(null, true)
+      })
     })
   }
 
@@ -134,52 +169,33 @@ var update_attempts = function(version, cb) {
 
     var count = Object.keys(db).length;
     if (count > 0 && exist) {
-      var key = ['version', version].join('-'),
+      var key = ['version', new_version].join('-'),
           attempt;
 
       if (db[key]) attempt = db[key].attempts;
-      else return create_version(version, cb);
+      else return create_version(new_version, cb);
 
       if (db[key].attempts < MAX_UPDATE_ATTEMPS) {
         // Number of attempts ++
-        update_versions(version, attempt, false, function(err) {
+        update_versions(old_version, new_version, attempt, false, function(err) {
           if (err) return cb(new Error("Unable to update local database, update cancelled"));
           cb(null, true);
         });
       } else {
         if (!db[key].notified) {
           // Send the event when the maximum update attemps are reached
-          package.get_update_data(function(res) {
-            var api = require('./agent/plugins/control-panel/api');
-            var data = {
-              name: 'device_client_updated',
-              info: {
-                status:  'failed',
-                old_ver: res.from,
-                new_ver: res.to,
-                ip:      res.public_ip,
-                country: res.country,
-                arch:    arch,
-                os:      os_name
-              }
-            }
-            api.push['event'](data, {}, function(err, res) {
-              if (err || res.statusCode != 200)
-                log("Error sending the fail upgrade event");
-              else {
-                log("Notifying update error to user");
-                update_versions(version, attempt, true, function(err) {
-                  if (err) log("Error updating notification status");
-                });
-              }
+          send_update_event('failed', null, function(err) {
+            if (err) return cb(new Error("Notifying update error to user"));
+            update_versions(old_version, new_version, attempt, true, function(err) {
+              if (err) return cb(new Error("Error updating notification status"));
             });
           });
         }
-        cb(null, false);
+        else return cb(null, false);
       }
     } else {
       // Set the new client version attempts in the local database
-      create_version(version, cb);
+      create_version(new_version, cb);
     }
   })
 }
@@ -344,13 +360,14 @@ package.get_latest = function(branch, current_version, dest, cb) {
 // called from lib/conf/install when a specific version is passed, e.g. 'config upgrade 1.2.3'
 package.get_version = function(version, dest, cb) {
   var keys   = require('./agent/plugins/control-panel/api/keys'),
-      shared = require('./conf/shared');
+      shared = require('./conf/shared'),
+      common = require('./common');
 
   if (process.argv.indexOf('test') != -1) return package.download_install(version, dest, cb)
   shared.keys.verify_current(function(err) {
     if (err) return cb(new Error("Missing user credencials, update cancelled for now"));
 
-    update_attempts(version, function(err, update) {
+    update_attempts(common.version, version, function(err, update) {
       if (err) return cb(err);
       if (update) {
         package.download_install(version, dest, function(err) {
@@ -431,6 +448,28 @@ package.install = function(zip, dest, cb) {
 
   })
 
+}
+
+package.check_update_success = function(version, cb) {
+  var key = ['version', version].join('-');
+  storage.all('versions', function(err, out) {
+    if (err || !out) return cb && cb(err);
+
+    var count = Object.keys(out).length;
+    if (out[key]) {
+      var from = out[key].from || null;
+      send_update_event('success', from, function(err) {
+        if (err) return cb(new Error("Notifying update error to user"));
+        storage.clear('versions', function(err) {
+          if (err) return cb(new Error("Error deleting update attempts registry"));
+          return cb && cb(err);
+        });
+      });
+    } else {
+      if (Object.keys(out).length > 0) storage.clear('versions');
+      return cb();
+    }
+  })
 }
 
 module.exports = package;

--- a/lib/package.js
+++ b/lib/package.js
@@ -91,6 +91,7 @@ var send_update_event = function(status, old_version, new_version, cb) {
   var keys   = require('./agent/plugins/control-panel/api/keys'),
       shared = require('./conf/shared');
   shared.keys.verify_current(function(err) {
+    // Get the local IP and the country
     package.get_update_data(function(res) {
       var api = require('./agent/plugins/control-panel/api');
       var data = {
@@ -154,6 +155,7 @@ var update_attempts = function(old_version, new_version, cb) {
 
   var create_version = function(version, cb) {
     var key = ['version', version].join('-');
+    // Before creating the registry the table it's cleared
     storage.clear('versions', function(err) {
       if (err) return cb(new Error("Unable to edit local database, update cancelled"));
       storage.set(key, {from: old_version, to: new_version, attempts: 1, notified: false}, function(err) {
@@ -282,8 +284,8 @@ releases.verify_checksum = function(version, filename, file, cb) {
 
 releases.download_verify = function(version, cb) {
 
-  var release   = ['prey', os_name, version, arch].join('-') + package_format,
-      url       = releases_url + version + '/' + release;
+  var release = ['prey', os_name, version, arch].join('-') + package_format,
+      url     = releases_url + version + '/' + release;
 
   releases.download(url, function(err, file) {
     if (err) return cb(err);
@@ -452,18 +454,22 @@ package.check_update_success = function(new_version, cb) {
     if (err || !db) return cb && cb(err);
 
     var count = Object.keys(db).length;
-    if (db[key] && !db[key].notified) {
+    if (db[key]) {
       // If the registry with the new version exists the event is sent, then the registry is deleted.
       var old_version = db[key].from || null;
+
       send_update_event('success', old_version, new_version, function(err) {
         if (err) return cb(new Error("Error sending the update success event"));
+
         storage.clear('versions', function(err) {
           if (err) return cb(new Error("Error deleting update attempts registry"));
           return cb && cb(err);
         });
       });
     } else {
-      if (Object.keys(db).length > 0) storage.clear('versions');
+      // Clear de database in the case there's an older update registry stored
+      if (Object.keys(db).length > 0)
+        storage.clear('versions');
       return cb();
     }
   })

--- a/lib/package.js
+++ b/lib/package.js
@@ -6,7 +6,6 @@ var fs              = require('fs'),
     cp              = require('child_process'),
     whenever        = require('whenever'),
     storage         = require('./agent/utils/storage');
-    device_keys     = require('./agent/utils/keys-storage');
     is_greater_than = require('./agent/helpers').is_greater_than,
     os_name         = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
     arch            = process.arch == 'x64' ? 'x64' : 'x86',
@@ -88,28 +87,6 @@ var move = function(from, to, cb) {
   like_a_boss(1);
 }
 
-var update_versions = function(old_version, new_version, attempt_del, notif_add, cb) {
-  var key = ["version", new_version].join("-"),
-      attempt_add = attempt_del,
-      notif_del = notif_add;
-
-  var version_del,
-      version_add,
-      obj_del = {},
-      obj_add = {};
-
-  if (notif_add) notif_del = !notif_add;
-  else attempt_add = attempt_del + 1;
-
-  version_del = { "from": old_version, "to": new_version, "attempts": attempt_del, "notified": notif_del };
-  version_add = { "from": old_version, "to": new_version, "attempts": attempt_add, "notified": notif_add };
-
-  obj_del[key] = version_del;
-  obj_add[key] = version_add;
-
-  storage.update(key, obj_del, obj_add, cb);
-}
-
 var send_update_event = function(status, old_version, new_version, cb) {
   var keys   = require('./agent/plugins/control-panel/api/keys'),
       shared = require('./conf/shared');
@@ -144,12 +121,35 @@ var send_update_event = function(status, old_version, new_version, cb) {
 // more update attemps and the user is gonna be notified.
 var update_attempts = function(old_version, new_version, cb) {
   var common = require('./common');
+
   var exist = function(db) {
     var key = ['version', version].join('-');
     if (db[key]) {
       return true;
     }
     return false;
+  }
+
+  var update_versions = function(old_version, new_version, attempt_del, notif_add, cb) {
+    var key = ["version", new_version].join("-"),
+        attempt_add = attempt_del,
+        notif_del = notif_add;
+
+    var version_del,
+        version_add,
+        obj_del = {},
+        obj_add = {};
+
+    if (notif_add) notif_del = !notif_add;
+    else attempt_add = attempt_del + 1;
+
+    version_del = { "from": old_version, "to": new_version, "attempts": attempt_del, "notified": notif_del };
+    version_add = { "from": old_version, "to": new_version, "attempts": attempt_add, "notified": notif_add };
+
+    obj_del[key] = version_del;
+    obj_add[key] = version_add;
+
+    storage.update(key, obj_del, obj_add, cb);
   }
 
   var create_version = function(version, cb) {
@@ -444,15 +444,18 @@ package.install = function(zip, dest, cb) {
 
 }
 
-package.check_update_success = function(version, cb) {
-  var key = ['version', version].join('-');
-  storage.all('versions', function(err, out) {
-    if (err || !out) return cb && cb(err);
+// called from lib/agent/updater if there's a new client version installed, if that the case the update success event is sent
+package.check_update_success = function(new_version, cb) {
+  var key = ['version', new_version].join('-');
 
-    var count = Object.keys(out).length;
-    if (out[key]) {
-      var from = out[key].from || null;
-      send_update_event('success', from, version, function(err) {
+  storage.all('versions', function(err, db) {
+    if (err || !db) return cb && cb(err);
+
+    var count = Object.keys(db).length;
+    if (db[key] && !db[key].notified) {
+      // If the registry with the new version exists the event is sent, then the registry is deleted.
+      var old_version = db[key].from || null;
+      send_update_event('success', old_version, new_version, function(err) {
         if (err) return cb(new Error("Error sending the update success event"));
         storage.clear('versions', function(err) {
           if (err) return cb(new Error("Error deleting update attempts registry"));
@@ -460,7 +463,7 @@ package.check_update_success = function(version, cb) {
         });
       });
     } else {
-      if (Object.keys(out).length > 0) storage.clear('versions');
+      if (Object.keys(db).length > 0) storage.clear('versions');
       return cb();
     }
   })

--- a/lib/package.js
+++ b/lib/package.js
@@ -110,19 +110,18 @@ var update_versions = function(old_version, new_version, attempt_del, notif_add,
   storage.update(key, obj_del, obj_add, cb);
 }
 
-var send_update_event = function(status, old, cb) {
+var send_update_event = function(status, old_version, new_version, cb) {
   var keys   = require('./agent/plugins/control-panel/api/keys'),
       shared = require('./conf/shared');
   shared.keys.verify_current(function(err) {
     package.get_update_data(function(res) {
-      var from = old || res.from;
       var api = require('./agent/plugins/control-panel/api');
       var data = {
         name: 'device_client_updated',
         info: {
           status:  status,
-          old_ver: from,
-          new_ver: res.to,
+          old_ver: old_version,
+          new_ver: new_version,
           ip:      res.public_ip,
           country: res.country,
           arch:    arch,
@@ -144,7 +143,7 @@ var send_update_event = function(status, old, cb) {
 // Update local update attemps db until the maximum number is reached, after that there's not gonna be
 // more update attemps and the user is gonna be notified.
 var update_attempts = function(old_version, new_version, cb) {
-
+  var common = require('./common');
   var exist = function(db) {
     var key = ['version', version].join('-');
     if (db[key]) {
@@ -184,8 +183,9 @@ var update_attempts = function(old_version, new_version, cb) {
       } else {
         if (!db[key].notified) {
           // Send the event when the maximum update attemps are reached
-          send_update_event('failed', null, function(err) {
-            if (err) return cb(new Error("Notifying update error to user"));
+          send_update_event('failed', common.version, new_version, function(err) {
+            if (err) return cb(new Error("Error sending the update failed event"));
+            log("Notifying update error to user")
             update_versions(old_version, new_version, attempt, true, function(err) {
               if (err) return cb(new Error("Error updating notification status"));
             });
@@ -308,22 +308,16 @@ var package = {};
 
 // called from here and lib/conf/install when the update process failed or succeeded respectively
 package.get_update_data = function(cb) {
-  var common = require('./common'),
-      data   = {from: null, to: null, public_ip: null, country: null};
+  var data   = {public_ip: null, country: null};
 
-  data.from = common.version;
-  releases.get_stable_version(function(err, ver) {
-    if (err) log("Unable to get last client version");
-    else data.to = ver;
-    needle.get('http://ipinfo.io/geo', function(err, resp, body) {
-      if (err || !body) {
-        log("Unable to get geolocation info");
-      } else {
-        data.public_ip = body.ip;
-        data.country   = body.country;
-      }
-      cb(data);
-    })
+  needle.get('http://ipinfo.io/geo', function(err, resp, body) {
+    if (err || !body) {
+      log("Unable to get geolocation info");
+    } else {
+      data.public_ip = body.ip;
+      data.country   = body.country;
+    }
+    cb(data);
   });
 }
 
@@ -458,8 +452,8 @@ package.check_update_success = function(version, cb) {
     var count = Object.keys(out).length;
     if (out[key]) {
       var from = out[key].from || null;
-      send_update_event('success', from, function(err) {
-        if (err) return cb(new Error("Notifying update error to user"));
+      send_update_event('success', from, version, function(err) {
+        if (err) return cb(new Error("Error sending the update success event"));
         storage.clear('versions', function(err) {
           if (err) return cb(new Error("Error deleting update attempts registry"));
           return cb && cb(err);


### PR DESCRIPTION
Fixes for the success update event:
- Now it's sent after the client reboots.
- The local registry includes the old version also.
- After the event it's sent, the local table 'versions' it's cleared.