### PR TITLE
Replace command in local db

### DIFF
--- a/lib/agent/utils/storage.js
+++ b/lib/agent/utils/storage.js
@@ -74,10 +74,8 @@ var remove = function(type, cb) {
 }
 
 var save = function(type, add, cb) {
-  load(type, function(err, db) {
-    if (db[Object.keys(add)])
-      return cb(new Error("The registry already exists"));
-
+  var key = Object.keys(add)[0];
+  exports.del(key, function(err) {
     var stmt   = db_comm.prepare(queries.INSERT(type));
     var to_add = new Buffer(JSON.stringify(add, null, 0)).toString('base64');
 


### PR DESCRIPTION
If the command already exists in the db, instead of cancel the saving it replaces the stored one.