### PR TITLE
'Other' device type fix for linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Merged pull requests:**
 
+- Device type fix for linux [\#338](https://github.com/prey/prey-node-client/pull/338) ([javo](https://github.com/javo))
 - Prey user watcher for mac [\#332](https://github.com/prey/prey-node-client/pull/332) ([javo](https://github.com/javo))
 - Ubuntu fixed hardware info [\#334](https://github.com/prey/prey-node-client/pull/334) ([javo](https://github.com/javo))
 - Over 10 MB files wipe error fix [\#335](https://github.com/prey/prey-node-client/pull/335) ([javo](https://github.com/javo))

--- a/lib/agent/providers/hardware/linux.js
+++ b/lib/agent/providers/hardware/linux.js
@@ -26,6 +26,8 @@ var data_fields = {
   }
 };
 
+var valid_types = ['Desktop', 'Laptop', 'Tablet'];
+
 exports.get_firmware_info = function(callback) {
 
   var get_value = function(output, string) {
@@ -48,8 +50,11 @@ exports.get_firmware_info = function(callback) {
 
         Object.keys(fields).map(function(key) {
           var val = get_value(stdout, fields[key]);
-          if (val)
+          if (val) {
+            if (key == 'device_type' && valid_types.indexOf(val) == -1)
+              val = 'Laptop';
             data[key] = val.trim();
+          }
         });
 
         done();


### PR DESCRIPTION
On linux when a device_type is different from Laptop, Desktop or Tablet (for example on a virtual machine the device type is 'Other') it assigns the Laptop type.