### PR TITLE
Fix file scanning on windows

### DIFF
--- a/lib/agent/providers/files/index.js
+++ b/lib/agent/providers/files/index.js
@@ -112,7 +112,7 @@ module.exports.get_tree = function(options, cb) {
   if (!dir) {
     switch (os_name) {
       case 'windows':
-        dir = 'C:\\';
+        dir = 'C:';
         break;
       case 'linux':
         dir = '/home/' + options.user;
@@ -127,7 +127,7 @@ module.exports.get_tree = function(options, cb) {
 
   var argsv; 
   if (os_name == 'windows')
-    argsv = [path.join(__dirname, 'tree.js'), options.depth, path.resolve(dir)];
+    argsv = [path.join(__dirname, 'tree.js'), options.depth, path.resolve('', dir + '\\')];
   else
     argsv = [path.join(__dirname, 'tree.js'), options.depth, '"' + dir + '"'];
   

--- a/lib/agent/providers/files/tree.js
+++ b/lib/agent/providers/files/tree.js
@@ -31,6 +31,9 @@ var directoryTreeToObj = function(dir, current_depth, depth, done) {
     if (err)
       return done(err);
 
+    if (os_name == 'windows')
+      dir = dir + '\\';
+
     var pending = list.length;
     if (!pending) {
       if (pending <= 0) {


### PR DESCRIPTION
File scanning fix for fileretrieval. After node version update the initial scanned directory was C:\Windows\system32 instead of C:\