### PR TITLE
Autoupdate improvements

### DIFF
--- a/lib/agent/index.js
+++ b/lib/agent/index.js
@@ -78,17 +78,7 @@ var run = function() {
   if (program.mode == 'console')
     return load_plugin('console');
 
-  if (!config.get('auto_update'))
-    return boot();
-
-  updater.check(function(err, new_version) {
-    if (err && err.code != 'NO_VERSIONS_SUPPORT')
-        handle_error(err);
-
-    if (!new_version) return boot();
-
-    logger.warn('Updated to version ' + new_version + '! Shutting down.');
-  });
+  return boot();
 }
 
 var boot = function() {
@@ -101,7 +91,7 @@ var boot = function() {
     commands.start_watching(); // add/remove from list when started or stopped
 
     if (config.get('auto_update'))
-      updater.check_every(3 * 60 * 60 * 1000); // check every 3 hours for new releases
+      updater.check_every(3 * 60 * 60 * 1000); // Every 3 hours allow checking for new releases
 
     logger.info('Initialized.');
     // We initialize the triggers after all the plugins have been enabled,

--- a/lib/agent/plugins/control-panel/long-polling/index.js
+++ b/lib/agent/plugins/control-panel/long-polling/index.js
@@ -8,6 +8,7 @@ var needle        = require('needle'),
     triggers      = require('./../../../actions/triggers'),
     lp_conf       = require('./../../../../conf/long-polling'),
     status_trigger = require('./../../../triggers/status'),
+    updater       = require('./../../../updater'),
     server        = require('./server'),
     Emitter       = require('events').EventEmitter;
 
@@ -99,6 +100,8 @@ var request = function() {
       if (len && len > 0) {
         logger.info('Got ' + len + ' commands.');
         process_commands(data);
+      } else {
+        if (config.get('auto_update')) updater.check_for_update();
       }
     });
 
@@ -112,6 +115,7 @@ var request = function() {
       status_code = res.statusCode;
       if (status_code !== 200) {
         propagate_error('Invalid response received with status code ' + res.statusCode);
+        if (config.get('auto_update')) updater.check_for_update();
         resp_timeout = 30000;
 
         if (status_code == 406) resp_timeout = 60000;

--- a/lib/agent/triggers/location/index.js
+++ b/lib/agent/triggers/location/index.js
@@ -73,6 +73,7 @@ var fetch_location = (type, callback) => {
 
     if (Object.keys(current).length == 0) {
       current = new_location;
+      exports.current = new_location;
       done(null, current);
       send_location(type, new_location);
       return hooks.trigger(event, new_location);
@@ -95,6 +96,7 @@ var fetch_location = (type, callback) => {
 
     if (distance >= 30 || (distance < 30 && better_loc())) {
       current = new_location;
+      exports.current = new_location;
       send_location(type, new_location);
     }
 
@@ -138,5 +140,6 @@ exports.stop = () => {
 };
 
 exports.events = [];
+exports.current = current;
 exports.send_location = send_location;
 exports.post_it = post_it;

--- a/lib/agent/updater.js
+++ b/lib/agent/updater.js
@@ -6,6 +6,8 @@ var join    = require('path').join,
     child_process = require('child_process'); // need to use child_process for stubbing to work in test
 
 var timer; // for interval check
+exports.upgrading = false;
+exports.check_enabled = true;
 
 var no_versions_support_error = function() {
   var err = new Error('No versions support.');
@@ -16,6 +18,7 @@ var no_versions_support_error = function() {
 var update_client = function(new_version, cb) {
 
   var child,
+      error,
       out = [],
       versions_path = system.paths.versions;
 
@@ -29,6 +32,7 @@ var update_client = function(new_version, cb) {
     var bin_path    = system.paths.package_bin; // /foo/bar/bin/prey
     var args        = ['config', 'upgrade', new_version];
   }
+  exports.upgrading = true;
 
   var let_the_child_go = function() {
     child.unref();
@@ -37,8 +41,7 @@ var update_client = function(new_version, cb) {
       // on windows and linux the daemon with wait 15 seconds, and in
       // osx (given that launchd doesn't support that option) it will
       // restart when changes are detected on the install path (from 'config activate')
-      if (process.platform != 'win32')
-        process.exit(0);
+      process.exit(0);
     })
   }
 
@@ -68,8 +71,24 @@ var update_client = function(new_version, cb) {
       // if the child succeeded, then it will print this in its stdout stream
       // that means it's time to let him go on his own, and complete his purpose in life.
       if (line.match('YOUARENOTMYFATHER')) {
-        logger.warn('Upgrade successful! See you in another lifetime, young one.');
-        let_the_child_go();
+        // Keep the process alive for a while in the case we get an error.
+        setTimeout(() => {
+          if (!error) {
+            logger.warn('Upgrade successful! See you in another lifetime, young one.');
+            exports.upgrading = false;
+            let_the_child_go();
+          }
+        }, 15000)
+      } else if (line.includes("Error")) {
+        if (error) return;
+        error = line;
+        // Notify error and stop upgrade process
+        common.package.update_version_attempt(common.version, new_version, false, true, error, (err) => {
+          if (err) logger.warn('Unable to notify the update error');
+          child.unref();
+          exports.upgrading = false;
+          return cb && cb(error);
+        });
       } else {
         logger.info(line.trim());
       }
@@ -79,6 +98,7 @@ var update_client = function(new_version, cb) {
 
   child.on('exit', function(code) {
     exists(join(versions_path, new_version), function(exists) {
+      exports.upgrading = false;
       if (exists) return cb && cb();
 
       var err = new Error('Upgrade to ' + new_version + ' failed. Exit code: ' + code);
@@ -89,6 +109,10 @@ var update_client = function(new_version, cb) {
 }
 
 var check_for_update = function(cb) {
+  if (!exports.check_enabled || exports.upgrading) return cb();
+
+  exports.check_enabled = false;
+
   var versions_path = system.paths.versions,
       branch = common.config.get('download_edge') == true ? 'edge' : 'stable';
 
@@ -109,7 +133,14 @@ exports.check = function(cb){
   if (!system.paths.versions)
     return cb && cb(no_versions_support_error());
 
-  check_for_update(cb);
+  // Command forces auto-update even if we're out of attempts
+  exports.check_enabled = true;
+  if (exports.upgrading) logger.warn('Already running upgrade process.')
+
+  common.package.delete_attempts((err) => {
+    last_time = null;
+    check_for_update(cb);
+  });
 };
 
 exports.check_every = function(interval, cb) {
@@ -117,10 +148,15 @@ exports.check_every = function(interval, cb) {
     return cb && cb(no_versions_support_error());
 
   var interval = interval || 3 * 60 * 60 * 1000; // three hours by default
-  timer = setInterval(check_for_update, interval); 
+  timer = setInterval(() => {
+    exports.check_enabled = true;
+    exports.upgrading = false;
+  }, interval);
 }
 
 exports.stop_checking = function() {
   if (timer) clearInterval(timer);
   timer = null;
 }
+
+exports.check_for_update = check_for_update;

--- a/lib/package.js
+++ b/lib/package.js
@@ -22,7 +22,7 @@ var releases_host   = 'https://downloads.preyproject.com',
     checksums       = 'shasums.json',
     package_format  = '.zip';
 
-var MAX_UPDATE_ATTEMPS = 3;
+var MAX_UPDATE_ATTEMPS = 60;
 
 /////////////////////////////////////////////////////////
 // helpers
@@ -88,36 +88,32 @@ var move = function(from, to, cb) {
   like_a_boss(1);
 }
 
-var send_update_event = function(status, old_version, new_version, cb) {
-  var keys   = require('./agent/plugins/control-panel/api/keys'),
-      shared = require('./conf/shared');
-  shared.keys.verify_current(function(err) {
-    if (err) return cb(new Error("Missing user credentials"));
-    // Get the local IP and the country
-    package.get_update_data(function(res) {
-      var api = require('./agent/plugins/control-panel/api');
-      var data = {
-        name: 'device_client_updated',
-        info: {
-          status:  status,
-          old_ver: old_version,
-          new_ver: new_version,
-          ip:      res.public_ip,
-          country: res.country,
-          arch:    arch,
-          os:      os_name
-        }
-      }
+var send_update_event = (type, status, old_version, new_version, attempt, error, cb) => {
+  var keys   = require('./agent/plugins/control-panel/api/keys');
 
-      api.push['event'](data, {json: true}, function(err, res) {
-        if (err || res.statusCode != 200)
-          return cb(new Error("Error sending the upgrade event"));
-        else {
-          log("Sending update event to the control panel");
-          return cb(null);
-        }
-      });
-    });
+  // Get the local IP, the country and location
+  package.get_update_data((res) => {
+    var data = {
+      name: 'client_install',
+      info: {
+        type:     type,
+        status:   status,
+        old_ver:  old_version,
+        new_ver:  new_version,
+        attempt:  attempt,
+        error:    error,
+        location: res.location,
+        ip:       res.public_ip,
+        country:  res.country,
+        arch:     arch,
+        os:       os_name,
+        key:      keys.get().device || null
+      }
+    }
+
+    package.post_event(data, (err) => {
+      return cb();
+    })
   });
 }
 
@@ -227,41 +223,29 @@ releases.download_verify = function(version, cb) {
 
 var package = {};
 
+package.post_event = (data, cb) => {
+  var common = require('./agent/common'),
+      url = 'https://solid.preyproject.com/api/v2/telemetry';
+
+  var opts = {
+    json: true,
+    user_agent: common.system.user_agent
+  }
+  needle.post(url, data, opts, (err) => {
+    return cb && cb(err);
+  });
+}
+
+package.delete_attempts = (cb) => {
+  storage.clear('versions', (err) => {
+    if (err) return cb(new Error("Error deleting update attempts registry: " + err.message));
+    return cb && cb(err);
+  });
+}
+
 // Update local update attemps db until the maximum number is reached, after that there's not gonna be
 // more update attemps and the user is gonna be notified.
-package.update_attempts = function(old_version, new_version, cb) {
-  var common = require('./common');
-
-  var exist = function(db) {
-    var key = ['version', version].join('-');
-    if (db[key]) {
-      return true;
-    }
-    return false;
-  }
-
-  var update_versions = function(old_version, new_version, attempt_del, notif_add, cb) {
-    var key = ["version", new_version].join("-"),
-        attempt_add = attempt_del,
-        notif_del = notif_add;
-
-    var version_del,
-        version_add,
-        obj_del = {},
-        obj_add = {};
-
-    if (notif_add) notif_del = !notif_add;
-    else attempt_add = attempt_del + 1;
-
-    version_del = { "from": old_version, "to": new_version, "attempts": attempt_del, "notified": notif_del };
-    version_add = { "from": old_version, "to": new_version, "attempts": attempt_add, "notified": notif_add };
-
-    obj_del[key] = version_del;
-    obj_add[key] = version_add;
-
-    storage.update(key, obj_del, obj_add, cb);
-  }
-
+package.update_version_attempt = (old_version, new_version, attempt_plus, set_notified, error, cb) => {
   var create_version = function(version, cb) {
     var key = ['version', version].join('-');
     // Before creating the registry the table it's cleared
@@ -274,48 +258,72 @@ package.update_attempts = function(old_version, new_version, cb) {
     })
   }
 
-  storage.all('versions', function(err, db) {
-    if (err) return cb(new Error("Unable to load local database, update cancelled"));
+  storage.all('versions', (err, db) => {
+    if (err) return cb(new Error("Unable to load local database"));
 
-    var count = Object.keys(db).length;
-    if (count > 0 && exist) {
-      var key = ['version', new_version].join('-'),
-          attempt;
+    var key = ['version', new_version].join('-');
 
-      if (db[key]) attempt = db[key].attempts;
-      else return create_version(new_version, cb);
+    if (db[key] && Object.keys(db).length > 0) {
 
-      if (db[key].attempts < MAX_UPDATE_ATTEMPS) {
-        // Number of attempts ++
-        update_versions(old_version, new_version, attempt, false, function(err) {
-          if (err) return cb(new Error("Unable to update local database, update cancelled"));
-          cb(null, true);
-        });
-      } else {
-        if (!db[key].notified) {
-          // Send the event when the maximum update attemps are reached
-          send_update_event('failed', common.version, new_version, function(err) {
-            if (err) return cb(new Error("Error sending the update failed event: " + err.message));
-            log("Notifying update error to user")
-            update_versions(old_version, new_version, attempt, true, function(err) {
-              if (err) return cb(new Error("Error updating notification status: " + err.message));
-            });
-          });
-        }
-        else return cb(null, false);
+      var version_del,
+          version_add,
+          obj_del = {},
+          obj_add = {},
+          current_attempt  = db[key].attempts,
+          already_notified = db[key].notified,
+          new_attempt = current_attempt;
+
+      // In the case the previous version attempt hasn't been notified
+      if (!already_notified) {
+        // logger.info("NOT NOTIFIED")
+        var state = error ? 'failed' : 'success';
+        // Enviar el evento de intento. No tengo el error disponible en esta etapa
+        send_update_event('update', state, old_version, new_version, current_attempt, error, (err) => {
+          if (err) log("Unable to notify previous attempt failure");
+        })
       }
+
+      if (attempt_plus) {
+        if (current_attempt < MAX_UPDATE_ATTEMPS)
+          new_attempt = current_attempt + 1;
+        else
+          return cb(null, false);
+      }
+
+      version_del = { "from": old_version, "to": new_version, "attempts": current_attempt, "notified": already_notified };
+      version_add = { "from": old_version, "to": new_version, "attempts": new_attempt, "notified": set_notified };
+
+      obj_del[key] = version_del;
+      obj_add[key] = version_add;
+
+      storage.update(key, obj_del, obj_add, (err) => {
+        if (err) return cb(new Error(""));
+        return cb(null, true)
+      });
+
     } else {
-      // Set the new client version attempts in the local database
-      create_version(new_version, cb);
+      create_version(new_version, (err) => {
+        if (err) return cb(new Error(""));
+        return cb(null, true) 
+      });
     }
-  })
+
+  });
 }
 
 // called from here and lib/conf/install when the update process failed or succeeded respectively
-package.get_update_data = function(cb) {
-  var data   = {public_ip: null, country: null};
+package.get_update_data = (cb) => {
+  var location  = require('./agent/triggers/location'),
+      data = {public_ip: null, country: null, location: {lat: null, lng: null}};
 
-  needle.get('http://ipinfo.io/geo', function(err, resp, body) {
+  loc = location.current;
+
+  if (loc && loc.lat && loc.lng) {
+    data.location.lat = loc.lat;
+    data.location.lon = loc.lng;
+  }
+
+  needle.get('http://ipinfo.io/geo', (err, resp, body) => {
     if (err || !body) {
       log("Unable to get geolocation info");
     } else {
@@ -358,23 +366,18 @@ package.get_latest = function(branch, current_version, dest, cb) {
 
 // called from lib/conf/install when a specific version is passed, e.g. 'config upgrade 1.2.3'
 package.get_version = function(version, dest, cb) {
-  var keys   = require('./agent/plugins/control-panel/api/keys'),
-      shared = require('./conf/shared'),
-      common = require('./common');
+  var common = require('./common');
 
-  shared.keys.verify_current(function(err) {
-    if (err) return cb(new Error("Missing user credencials, update cancelled for now"));
-
-    package.update_attempts(common.version, version, function(err, update) {
-      if (err) return cb(err);
-      if (update) {
-        package.download_install(version, dest, function(err) {
-          cb(err, version);
-        });
-      } else {
-        return cb(new Error("Maximum number of upgrade attempts reached"));
-      }
-    });
+  // New registry or increment attempt count
+  package.update_version_attempt(common.version, version, true, false, "Failed previous attempt", (err, update) => {
+    if (err) return cb(err);
+    if (update) {
+      package.download_install(version, dest, function(err) {
+        cb(err, version);
+      });
+    } else {
+      return cb(new Error("Maximum number of upgrade attempts reached"));
+    }
   });
 }
 
@@ -457,12 +460,13 @@ package.check_update_success = function(new_version, versions_path, cb) {
 
     if (db[key] && !db[key].notified) {
       // If the registry with the new version exists the event is sent, then the registry is deleted.
-      var old_version = db[key].from || null;
+      var old_version = db[key].from || null,
+          attempt = db[key].attempts || null;
 
-      if (os_name == 'windows')   // for now only for windows (client can't delete into /usr dir)
-        package.delete_older_versions(old_version, new_version, versions_path);
+      // Delete older versions previous to the last 2
+      package.delete_older_versions(old_version, new_version, versions_path);
 
-      send_update_event('success', old_version, new_version, function(err) {
+      send_update_event('update', 'success', old_version, new_version, attempt, null, (err) => {
         if (err) return cb(new Error("Error sending the update success event: " + err.message));
 
         storage.clear('versions', function(err) {
@@ -486,6 +490,7 @@ package.delete_older_versions = function(old_ver, new_ver, versions_path) {
 
   // Get all the versions from the directory, then exclude the new and the last one
   fs.readdir(versions_path, function(err, all_versions) {
+    if (!all_versions) return;
     all_versions = all_versions.filter(function(version) {
       return version != old_ver && version != new_ver && version != common.version;
     })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -44,6 +44,7 @@ helpers.fake_spawn_child = function() {
   var child = new Emitter();
   child.stdout = new Emitter();
   child.stderr = new Emitter();
+  child.unref = function() {}
   return child;
 }
 

--- a/test/lib/agent/providers/geo/wifi_strategy.js
+++ b/test/lib/agent/providers/geo/wifi_strategy.js
@@ -149,7 +149,7 @@ describe('location', function() {
 
         it('works', function(done) {
           provider_stub.restore();
-          this.timeout(7000); // response may take longer
+          this.timeout(10000); // response may take longer
 
           wifi_strat(function(err, data) {
             if (err) {


### PR DESCRIPTION
This PR includes:
- Client version update reformulation. The client is gonna check for updates when it receives a response for the long-polling request, waiting 3 hours for the next attempt.
- It improves the errors detection into the upgrade process and notifies on every failed or success attempt
- Deletes old client versions keeping the last 2.
