### PR TITLE
Set as missing command for automations

### DIFF
--- a/lib/agent/actions/triggers/index.js
+++ b/lib/agent/actions/triggers/index.js
@@ -158,7 +158,8 @@ function set_up_hooks() {
         }
 
         setTimeout(() => {
-          action.action.options.trigger_id = action.trigger_id;
+          if (action.action.options)
+            action.action.options.trigger_id = action.trigger_id;
           commands.perform(action.action)
         }, timeout);
       })
@@ -321,7 +322,8 @@ exports.activate = (trigger) => {
         timeout = action.delay;
 
       setTimeout(() => {
-        action.action.options.trigger_id = trigger.id;
+        if (action.action.options)
+          action.action.options.trigger_id = trigger.id;
         commands.perform(action.action)
       }, timeout);
     })

--- a/lib/agent/commands.js
+++ b/lib/agent/commands.js
@@ -6,7 +6,8 @@ var join      = require('path').join,
     providers = require('./providers'),
     reports   = require('./reports'),
     updater   = require('./updater'),
-    storage   = require('./utils/storage');
+    storage   = require('./utils/storage'),
+    devices   = require('./plugins/control-panel/api/devices');
 
 var logger    = common.logger;
 var watching  = false; // flag for storing new commands when fired
@@ -119,6 +120,25 @@ exports.perform = function(command) {
   if (command.command === "get" && command.target === "report" && command.options.interval) {
     command.command = 'report';
     command.target = 'stolen';
+  }
+
+  // Automation command to mark as missing and recovered from here
+  if (command.command === "start" && (command.target === "missing" || command.target === "recover")) {
+    var set_missing = command.target === "missing" ? true : false;
+
+    // Set as missing or recovered on the control panel
+    devices.post_missing(set_missing, (err) => {
+      if (err) logger.warn('Unable to set missing state to the device: ' + err.message);
+    });
+
+    // Initialize (or end) reports process on the client
+    if (set_missing) {
+      command.command = 'report';
+      command.target = 'stolen';
+    } else {
+      command.command = 'cancel';
+      command.target = 'stolen';
+    }
   }
 
   var type    = command.command || command.name,

--- a/lib/agent/plugins/control-panel/api/devices.js
+++ b/lib/agent/plugins/control-panel/api/devices.js
@@ -103,7 +103,10 @@ exports.post_missing = (opt, cb) => {
   if (!keys.get().api || !keys.get().device)
     return cb(errors.get('MISSING_KEY'));
 
-  request.post('/devices/' + keys.get().device + '/missing/' + opt, null, (err, resp) => {
+  if (opt == null || typeof opt != 'boolean')
+    return cb(new Error("Invalid option for missing action"));
+
+  request.post('/devices/' + keys.get().device + '/missing/' + opt.toString(), null, (err, resp) => {
     if (err) return cb(err);
 
     if (resp.statusCode === 401)

--- a/lib/agent/plugins/control-panel/api/test/post_missing_spec.js
+++ b/lib/agent/plugins/control-panel/api/test/post_missing_spec.js
@@ -46,7 +46,7 @@ describe('post missing', () => {
     })
 
     it('doesnt fail', () => {
-      post_missing(null, (err, resp) => {
+      post_missing(true, (err, resp) => {
         should.not.exist(err);
       })
     })
@@ -64,7 +64,7 @@ describe('post missing', () => {
     })
 
     it('callbacks true', () => {
-      post_missing(null, (err, resp) => {
+      post_missing(true, (err, resp) => {
         should.exist(err);
         err.message.should.equal('Missing state already set.');
       })
@@ -83,8 +83,17 @@ describe('post missing', () => {
     })
 
     it('callbacks true', () => {
-      post_missing(null, (err, resp) => {
+      post_missing(false, (err, resp) => {
         err.message.should.equal('Invalid credentials.');
+      })
+    })
+  })
+
+  describe('and option is null', () => {
+
+    it('callbacks true', () => {
+      post_missing(null, (err, resp) => {
+        err.message.should.equal('Invalid option for missing action');
       })
     })
   })

--- a/lib/conf/cli.js
+++ b/lib/conf/cli.js
@@ -47,30 +47,6 @@ var via_npm   = function() {
   return !!(process.env.npm_package_version || process.env.npm_lifecycle_script);
 }
 
-var restart_client = () => {
-  var client_pid = function(cb) {
-    var process_id;
-    if (os_name == 'windows') {
-      process_id = `for /f "tokens=2 delims=," %F in ('tasklist /nh /fi "imagename eq node.exe" /fo csv') do @echo %~F`;
-    } else {
-      var awk = os_name == 'mac' ? 2 : 1
-      process_id = "ps -u prey | grep prx | awk '{print $'" + awk + "'}'";
-    }
-
-    exec(process_id, function(err, pid) {
-      if (err) return cb("Error getting client process id:" + err)
-      pid = pid.toString().split("\r\n")[0];
-      cb(null, pid)
-    })
-  }
-
-  client_pid(function(err, pid) {
-    if (err || !pid) return;
-    var restart_cmd = os_name == 'windows' ? 'taskkill /F /PID ' : 'kill -9 ';
-    exec(restart_cmd + pid);
-  })
-}
-
 var start = function(cb) {
 
   var run = function(scope, command) {
@@ -100,10 +76,6 @@ var start = function(cb) {
       cmd.parameters(['-e', '--email'], 'Email')
       cmd.parameters(['-p', '--password'], 'Password')
       run_if_writable(cmd, account.authorize);
-
-      setTimeout(() => {  // Wait for the key to be set
-        restart_client();
-      }, 2000)
     });
 
     sub.command('verify', 'Verifies API & Device keys, optionally saving them to config.', function(cmd) {

--- a/test/lib/agent/commands.js
+++ b/test/lib/agent/commands.js
@@ -1,10 +1,18 @@
-var helpers = require('./../../helpers'),
-    should = require('should'),
-    sinon = require('sinon'),
-    commands = helpers.load('commands'),
-    reports = helpers.load('reports'),
-    storage   = helpers.load('utils/storage');
-    hooks = helpers.load('hooks');
+var path      = require('path'),
+    join      = path.join,
+    helpers   = require('./../../helpers'),
+    should    = require('should'),
+    sinon     = require('sinon'),
+    commands  = helpers.load('commands'),
+    reports   = helpers.load('reports'),
+    root_path = path.resolve(__dirname, '..', '..', '..'),
+    lib_path  = path.join(root_path, 'lib'),
+    api_path  = join(lib_path, 'agent', 'plugins', 'control-panel', 'api'),
+    storage   = helpers.load('utils/storage'),
+    keys      = require(join(api_path, 'keys')),
+    devices   = require(join(api_path, 'devices')),
+    request   = require(join(api_path, 'request')),
+    hooks     = helpers.load('hooks');
 
 describe('perform', function() {
 
@@ -53,6 +61,62 @@ describe('perform', function() {
       commands.perform(command);
 
     });
+
+  });
+
+  describe('when receiving a start missing/recovered command', () => {
+    var missing_command = { command: "start", target: "missing", options: {interval: 2}},
+        recover_command = { command: "start", target: "recover", options: {}};
+
+    before(() => {
+      keys_get_stub = sinon.stub(keys, 'get').callsFake(() => {
+        return { api: 'aaaaaaaaaa', device: 'bbbbbb' }
+      });
+      missing_spy = sinon.spy(devices, 'post_missing');
+      stub_request = sinon.stub(request, 'post').callsFake((path, data, opts, cb) => { return; });
+      report_stub = sinon.stub(reports, 'get').callsFake((report_name, options, callback) => {
+        return true;
+      });
+    })
+
+    after(() => {
+      keys_get_stub.restore();
+      missing_spy.restore();
+      stub_request.restore();
+      report_stub.restore();
+    })
+
+    it('requests to set the device as missing and its set as stolen', (done) => {
+
+      function command_assertion(method, target, options) {
+        method.should.equal(reports.get);
+        target.should.equal('stolen');
+        options.should.equal(missing_command.options);
+        hooks.remove('command', command_assertion);
+        missing_spy.calledOnce.should.equal(true);
+        done();
+      }
+
+      hooks.on('command', command_assertion);
+      commands.perform(missing_command);
+
+    })
+
+    it('requests to set the device as recovered and its set as recovered', (done) => {
+
+      function command_assertion(method, target, options) {
+        method.should.equal(reports.cancel);
+        target.should.equal('stolen');
+        options.should.equal(recover_command.options);
+        hooks.remove('command', command_assertion);
+        missing_spy.calledTwice.should.equal(true);
+        done();
+      }
+
+      hooks.on('command', command_assertion);
+      commands.perform(recover_command);
+
+    })
 
   });
 


### PR DESCRIPTION
Automation command to set device as missing or recovered from the node client.