### PR TITLE
Switch Linux scripts to python3 and Gtk 3

### DIFF
--- a/lib/agent/actions/alert/linux/flash.py
+++ b/lib/agent/actions/alert/linux/flash.py
@@ -1,9 +1,9 @@
 #!/bin/sh
-''':'
+""":'
 ':'; python=$(command -v python)
 ':'; [ -z "$python" ] || [ -n "${python##*usr*}" ] && python="/usr/bin/python"
 ':'; exec "$python" "$0" "$@"
-'''
+"""
 
 # coding: utf8
 
@@ -14,7 +14,8 @@
 # GPLv3 Licensed
 #############################################
 
-import os, sys
+import os
+import sys
 import gtk
 import pango
 import argparse
@@ -22,232 +23,243 @@ import base64
 import gobject
 import math
 
-FONT = 'Liberation Sans'
+FONT = "Liberation Sans"
 
-data = "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABZklEQVRYR+2VvW0CQRCFwWCTQQDGEg0Q0AWBK6EAZy7AfwVYwvwFxEADtitAuAHnNIDk2OI96UY6obvdmbngkkN60gI7+76dnZ2t10r+1Ev2r1UAVQZCGWijQP+g/4KF2kH8KW+NEMAjgobQpABEH7HfyRqHLIgQAP/7gG6cEGL+gviNJwOMIcQMujZC0PwLeg2Zi0HsiAkxh5pKCLW5FkDmaSDEnGnfxnZmAZC5CwwaOZm4TaVdZW4FkPlLDK4uIFzmHoAsiC5+/EwKbqdJe3qOtxUzbgXxio685t4MyAYGGPxCe+gecnVMbwbuYMgO9wSNoVZOYUZPxANAczYZmvPMucbUC2EFkPYq5rJDd9u2AEiTeU52fpleF4QWQO45O1zoqpnfDg0AzS333AQRA+glBcdXzdJk1A9YCIDm3Pmb0TxdmNEHLATwgJWOTvM0xDu+rKGfrKYQO4JoIyk6oQKoMlB6Bs6DNUoh5TlqhAAAAABJRU5ErkJggg=="
+data = "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABZklEQVRYR+2VvW0CQRCFwWCTQQDGEg0Q0AWBK6EAZy7AfwVYwvwFxEADtitAuAHnNIDk2OI96UY6obvdmbngkkN60gI7+76dnZ2t10r+1Ev2r1UAVQZCGWijQP+g/4KF2kH8KW+NEMAjgobQpABEH7HfyRqHLIgQAP/7gG6cEGL+gviNJwOMIcQMujZC0PwLeg2Zi0HsiAkxh5pKCLW5FkDmaSDEnGnfxnZmAZC5CwwaOZm4TaVdZW4FkPlLDK4uIFzmHoAsiC5+/EwKbqdJe3qOtxUzbgXxio685t4MyAYGGPxCe+gecnVMbwbuYMgO9wSNoVZOYUZPxANAczYZmvPMucbUC2EFkPYq5rJDd9u2AEiTeU52fpleF4QWQO45O1zoqpnfDg0AzS333AQRA+glBcdXzdJk1A9YCIDm3Pmb0TxdmNEHLATwgJWOTvM0xDu+rKGfrKYQO4JoIyk6oQKoMlB6Bs6DNUoh5TlqhAAAAABJRU5ErkJggg=="  # noqa: E501
+
 
 def write(str):
-  print str
-  sys.stdout.flush()
+    print(str)
+    sys.stdout.flush()
+
 
 class Alert:
-  entry = None
-  respondable = False
-  sending = False
+    entry = None
+    respondable = False
+    sending = False
 
-  scale   = 1
-  input_width  = 600 # will be filled
-  input_height = 30
+    scale = 1
+    input_width = 600  # will be filled
+    input_height = 30
 
-  def exit(self):
-    os._exit(66)
+    def exit(self):
+        os._exit(66)
 
-  def update_button_and_exit(self):
-    self.button.set_label('Message Sent!')
-    self.button.set_sensitive(True)
-    gobject.timeout_add(1000, self.exit)
+    def update_button_and_exit(self):
+        self.button.set_label("Message Sent!")
+        self.button.set_sensitive(True)
+        gobject.timeout_add(1000, self.exit)
 
-  def enter_pressed(self, widget):
-    # print "Enter pressed"
-    str = self.entry.get_text()
-    if self.sending or str == "" or str == self.respondable:
-      return True
+    def enter_pressed(self, widget):
+        # print("Enter pressed")
+        str = self.entry.get_text()
+        if self.sending or str == "" or str == self.respondable:
+            return True
 
-    self.sending = True
-    write("User input: " + str)
-    self.button.set_label('Submitting...')
-    self.button.set_sensitive(False)
-    gobject.timeout_add(2000, self.update_button_and_exit)
+        self.sending = True
+        write("User input: " + str)
+        self.button.set_label("Submitting...")
+        self.button.set_sensitive(False)
+        gobject.timeout_add(2000, self.update_button_and_exit)
 
-  def button_clicked(self, widget):
-    if self.entry:
-      self.enter_pressed(widget)
-    elif self.respondable:
-      self.add_input()
-      self.button.set_label('Submit')
-    else:
-      self.exit()
+    def button_clicked(self, widget):
+        if self.entry:
+            self.enter_pressed(widget)
+        elif self.respondable:
+            self.add_input()
+            self.button.set_label("Submit")
+        else:
+            self.exit()
 
-  def close_button_clicked(self, widget):
-    # print "Close button clicked"
-    self.exit()
+    def close_button_clicked(self, widget):
+        # print "Close button clicked"
+        self.exit()
 
-  def put(self, container, child, x, y):
-    fixed = gtk.Fixed()
-    fixed.put(child, x, y)
-    container.pack_start(fixed, False, False, 0)
+    def put(self, container, child, x, y):
+        fixed = gtk.Fixed()
+        fixed.put(child, x, y)
+        container.pack_start(fixed, False, False, 0)
 
-  def add_input(self):
+    def add_input(self):
 
-    entry = gtk.Entry(max=0)
-    # entry.set_max_length(40)
-    entry.set_inner_border(None)
-    entry.set_width_chars(24)
-    entry.set_visibility(True)
-    entry.set_has_frame(True)
-    entry.set_editable(True)
+        entry = gtk.Entry(max=0)
+        # entry.set_max_length(40)
+        entry.set_inner_border(None)
+        entry.set_width_chars(24)
+        entry.set_visibility(True)
+        entry.set_has_frame(True)
+        entry.set_editable(True)
 
-    entry.set_size_request(self.input_width, self.input_height * self.scale)
-    entry.modify_base(gtk.STATE_NORMAL, gtk.gdk.color_parse('#FFFFFF'))
-    entry.modify_font(pango.FontDescription(FONT + " 11"))
+        entry.set_size_request(self.input_width, self.input_height * self.scale)
+        entry.modify_base(gtk.STATE_NORMAL, gtk.gdk.color_parse("#FFFFFF"))
+        entry.modify_font(pango.FontDescription(FONT + " 11"))
 
-    entry.connect('activate', self.enter_pressed)
-    entry.show()
-    self.entry = entry
+        entry.connect("activate", self.enter_pressed)
+        entry.show()
+        self.entry = entry
 
-    fixed = gtk.Fixed()
-    fixed.put(self.entry, self.left_offset, -80 * self.scale)
-    fixed.show()
-    self.box.pack_start(fixed, False, False, 0)
+        fixed = gtk.Fixed()
+        fixed.put(self.entry, self.left_offset, -80 * self.scale)
+        fixed.show()
+        self.box.pack_start(fixed, False, False, 0)
 
-  def new_label(self, text, font_size):
-    label = gtk.Label()
-    label.set_markup('<span foreground="#ffffff">' + text + '</span>');
-    label.modify_font(pango.FontDescription(FONT + ' ' + str(font_size)))
-    # label.set_alignment(0.01, 0)
-    label.set_alignment(0, 0)
-    label.set_line_wrap(True)
-    return label
+    def new_label(self, text, font_size):
+        label = gtk.Label()
+        label.set_markup('<span foreground="#ffffff">' + text + "</span>")
+        label.modify_font(pango.FontDescription(FONT + " " + str(font_size)))
+        # label.set_alignment(0.01, 0)
+        label.set_alignment(0, 0)
+        label.set_line_wrap(True)
+        return label
 
-  def create_window(self, bg_color):
-    self.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
+    def create_window(self, bg_color):
+        self.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
 
-    self.window.set_title("Prey Alert")
-    self.window.modify_bg(gtk.STATE_NORMAL, bg_color)
+        self.window.set_title("Prey Alert")
+        self.window.modify_bg(gtk.STATE_NORMAL, bg_color)
 
-    self.window.stick()
-    self.window.set_deletable(False)
-    self.window.set_decorated(False)
-    self.window.set_border_width(0)
-    self.window.set_keep_above(True)
-    self.window.set_resizable(False)
+        self.window.stick()
+        self.window.set_deletable(False)
+        self.window.set_decorated(False)
+        self.window.set_border_width(0)
+        self.window.set_keep_above(True)
+        self.window.set_resizable(False)
 
-  def __init__(self):
+    def __init__(self):
 
-    button_text = "Close"
-    title = args.title
+        button_text = "Close"
+        title = args.title
 
-    if args.entry is not None:
-      self.respondable = args.entry
-      button_text = "Send Reply"
+        if args.entry is not None:
+            self.respondable = args.entry
+            button_text = "Send Reply"
 
-    red = gtk.gdk.color_parse('#B22222')
-    blue = gtk.gdk.color_parse('#2168C6')
+        red = gtk.gdk.color_parse("#B22222")
+        blue = gtk.gdk.color_parse("#2168C6")
 
-    if args.level == 'warning' or args.level == 'warn':
-      bg_color = red
-      if title == 'Important':
-        title = 'Warning'
-    else:
-      bg_color = blue
+        if args.level == "warning" or args.level == "warn":
+            bg_color = red
+            if title == "Important":
+                title = "Warning"
+        else:
+            bg_color = blue
 
-    ###################################
-    # widths and heights
-    ###################################
+        ###################################
+        # widths and heights
+        ###################################
 
-    self.create_window(bg_color) # sets self.window
+        self.create_window(bg_color)  # sets self.window
 
-    main_screen_width   = self.window.get_screen().get_monitor_geometry(0).width
-    main_screen_height  = self.window.get_screen().get_monitor_geometry(0).height
+        main_screen_width = self.window.get_screen().get_monitor_geometry(0).width
+        main_screen_height = self.window.get_screen().get_monitor_geometry(0).height
 
-    if main_screen_width > 2000:
-      self.scale = 2
+        if main_screen_width > 2000:
+            self.scale = 2
 
-    one_third_width     = main_screen_width / 3
-    elements_width      = one_third_width * 2
-    base_height         = 150 * self.scale
+        one_third_width = main_screen_width / 3
+        elements_width = one_third_width * 2
+        base_height = 150 * self.scale
 
-    if args.entry is not None:
-      base_height += 30 * self.scale
+        if args.entry is not None:
+            base_height += 30 * self.scale
 
-    letters_per_line = elements_width / (8 * self.scale)
-    lines = int(math.ceil(len(args.message) / float(letters_per_line)))
-    text_height = 15 + (lines * 22 * self.scale)
-    window_height = text_height + base_height
+        letters_per_line = elements_width / (8 * self.scale)
+        lines = int(math.ceil(len(args.message) / float(letters_per_line)))
+        text_height = 15 + (lines * 22 * self.scale)
+        window_height = text_height + base_height
 
-    # these are needed later to position the input
-    self.input_width    = elements_width
-    self.left_offset    = one_third_width / 2 # the other have should be to the right
-    right_offset   = self.left_offset + elements_width
+        # these are needed later to position the input
+        self.input_width = elements_width
+        self.left_offset = one_third_width / 2  # the other have should be to the right
+        right_offset = self.left_offset + elements_width
 
-    # print "Letters per line: %d" % letters_per_line
-    # print "Lines: %d" % lines
-    # print "Left offset: %d" % self.left_offset
-    # print "Right offset: %d" % right_offset
+        # print "Letters per line: %d" % letters_per_line
+        # print "Lines: %d" % lines
+        # print "Left offset: %d" % self.left_offset
+        # print "Right offset: %d" % right_offset
 
-    # set vbox position and move main window
-    vbox = gtk.VBox(False, 0)
-    top_offset = (main_screen_height - window_height) / 2
-    vbox.set_size_request(main_screen_width, window_height)
-    self.window.move(0, top_offset)
-    self.window.add(vbox)
-    self.box = vbox
+        # set vbox position and move main window
+        vbox = gtk.VBox(False, 0)
+        top_offset = (main_screen_height - window_height) / 2
+        vbox.set_size_request(main_screen_width, window_height)
+        self.window.move(0, top_offset)
+        self.window.add(vbox)
+        self.box = vbox
 
-    ###################################
-    # elements
-    ###################################
+        ###################################
+        # elements
+        ###################################
 
-    # title
-    title = self.new_label(title, 22)
-    self.put(self.box, title, self.left_offset, 20 * self.scale)
+        # title
+        title = self.new_label(title, 22)
+        self.put(self.box, title, self.left_offset, 20 * self.scale)
 
-    # load image from data
-    image = gtk.Image()
-    loader = gtk.gdk.PixbufLoader()
-    loader.set_size(32, 32)
-    loader.write(base64.standard_b64decode(data))
-    loader.close()
-    image.set_from_pixbuf(loader.get_pixbuf())
+        # load image from data
+        image = gtk.Image()
+        loader = gtk.gdk.PixbufLoader()
+        loader.set_size(32, 32)
+        loader.write(base64.standard_b64decode(data))
+        loader.close()
+        image.set_from_pixbuf(loader.get_pixbuf())
 
-    # add image and render close button
-    close_button = gtk.Button()
-    # close_button.set_size_request(42, 42)
-    close_button.set_relief(gtk.RELIEF_NONE)
-    close_button.set_image(image)
-    close_button.connect('clicked', self.close_button_clicked)
+        # add image and render close button
+        close_button = gtk.Button()
+        # close_button.set_size_request(42, 42)
+        close_button.set_relief(gtk.RELIEF_NONE)
+        close_button.set_image(image)
+        close_button.connect("clicked", self.close_button_clicked)
 
-    fixed = gtk.Fixed()
-    fixed.put(close_button, 0, 0)
-    fixed.set_size_request(40 * self.scale, 40 * self.scale)
-    self.put(self.box, fixed, right_offset - 30, -40 * self.scale) # minus the width and height of itself for x/y coords
+        fixed = gtk.Fixed()
+        fixed.put(close_button, 0, 0)
+        fixed.set_size_request(40 * self.scale, 40 * self.scale)
+        # minus the width and height of itself for x/y coords
+        self.put(self.box, fixed, right_offset - 30, -40 * self.scale)
 
-    # text area
-    text = gtk.TextBuffer()
-    text.set_text(args.message)
-    textview = gtk.TextView(text)
-    textview.set_size_request(elements_width, text_height)
-    textview.set_wrap_mode(gtk.WRAP_WORD)
-    textview.set_editable(False)
-    textview.modify_base(gtk.STATE_NORMAL, bg_color)
-    textview.modify_text(gtk.STATE_NORMAL, gtk.gdk.color_parse('white'))
-    textview.modify_font(pango.FontDescription(FONT + " 11"))
-    textview.set_pixels_inside_wrap(3)
-    self.put(vbox, textview, self.left_offset, 20)
+        # text area
+        text = gtk.TextBuffer()
+        text.set_text(args.message)
+        textview = gtk.TextView(text)
+        textview.set_size_request(elements_width, text_height)
+        textview.set_wrap_mode(gtk.WRAP_WORD)
+        textview.set_editable(False)
+        textview.modify_base(gtk.STATE_NORMAL, bg_color)
+        textview.modify_text(gtk.STATE_NORMAL, gtk.gdk.color_parse("white"))
+        textview.modify_font(pango.FontDescription(FONT + " 11"))
+        textview.set_pixels_inside_wrap(3)
+        self.put(vbox, textview, self.left_offset, 20)
 
-    # close/reply button
-    button = gtk.Button(button_text)
-    # button.set_relief(gtk.RELIEF_NONE)
-    button.set_size_request(120 * self.scale, 30 * self.scale)
-    button.modify_font(pango.FontDescription(FONT + " 16"))
-    button.connect('clicked', self.button_clicked)
-    self.button = button
-    bottom = 20
-    if args.entry is not None:
-      bottom += 35
+        # close/reply button
+        button = gtk.Button(button_text)
+        # button.set_relief(gtk.RELIEF_NONE)
+        button.set_size_request(120 * self.scale, 30 * self.scale)
+        button.modify_font(pango.FontDescription(FONT + " 16"))
+        button.connect("clicked", self.button_clicked)
+        self.button = button
+        bottom = 20
+        if args.entry is not None:
+            bottom += 35
 
-    self.put(vbox, button, self.left_offset, bottom * self.scale)
+        self.put(vbox, button, self.left_offset, bottom * self.scale)
 
-    button.grab_focus()
-    self.window.show_all()
+        button.grab_focus()
+        self.window.show_all()
+
 
 if __name__ == "__main__":
 
-  parser = argparse.ArgumentParser(description='Shows an onscreen message.')
-  parser.add_argument('message', metavar='message', help='Message to show')
-  parser.add_argument('-t', '--title', dest='title', default='Important', help='Title to show above.')
-  parser.add_argument('-e', '--entry', dest='entry', help='Adds an text input.')
-  parser.add_argument('-l', '--level', dest='level', help='Warning level. "warning" or "info" (default)')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser(description="Shows an onscreen message.")
+    parser.add_argument("message", metavar="message", help="Message to show")
+    parser.add_argument(
+        "-t", "--title", dest="title", default="Important", help="Title to show above."
+    )
+    parser.add_argument("-e", "--entry", dest="entry", help="Adds an text input.")
+    parser.add_argument(
+        "-l",
+        "--level",
+        dest="level",
+        help='Warning level. "warning" or "info" (default)',
+    )
+    args = parser.parse_args()
 
-  alert = Alert()
-  gtk.main()
+    alert = Alert()
+    gtk.main()

--- a/lib/agent/actions/lock/linux/prey-lock
+++ b/lib/agent/actions/lock/linux/prey-lock
@@ -1,7 +1,7 @@
 #!/bin/sh
 ''':'
 ':'; python=$(command -v python)
-':'; [ -z "$python" ] || [ -n "${python##*usr*}" ] && python="/usr/bin/python"
+':'; [ -z "$python" ] || [ -n "${python##*usr*}" ] && python="/usr/bin/python3"
 ':'; exec "$python" "$0" "$@"
 '''
 
@@ -12,266 +12,307 @@
 # GPLv3 License
 #############################################
 
-import os, sys, gtk, pango
-from gobject import timeout_add
+import os
+import sys
 from hashlib import md5
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+from gi.repository import GLib
+from gi.repository import Gdk
+from gi.repository import GdkPixbuf
+from gi.repository import Pango
 
 image_file = "/../lib/bg-lock.png"
 
+
 def write(text):
-	print text
-	sys.stdout.flush()
+    print(text)
+    sys.stdout.flush()
+
 
 class Lock:
-	def get_md5(self, string):
-		return md5(string).hexdigest()
+    def get_md5(self, string):
+        return md5(string.encode("utf-8")).hexdigest()
 
-	def hide_error(self):
-		self.label.hide()
-		return False # stops timeout from repeating
+    def hide_error(self):
+        self.label.hide()
+        return False  # stops timeout from repeating
 
-	def enter_callback(self, widget, entry):
-		hashed_text = self.get_md5(entry.get_text())
-		# print hashed_text
+    def enter_callback(self, widget, entry):
+        hashed_text = self.get_md5(entry.get_text())
+        # print hashed_text
 
-		if hashed_text != passwd:
-			write("Invalid password")
-			self.label.show()
-			timeout_add(3000, self.hide_error)
-			return True
-		else:
-			enable_XF86Switch()
-			print 'Correctomondo. PC Unlocked.'
-			# self.label.set_markup('<span foreground="green">Very good. Access granted.</span>');
-			# self.label.show()
-			os._exit(66)
+        if hashed_text != passwd:
+            write("Invalid password")
+            self.label.show()
+            GLib.timeout_add(3000, self.hide_error)
+            return True
+        else:
+            enable_XF86Switch()
+            print("Correctomondo. PC Unlocked.")
+            # self.label.set_markup(
+            #     '<span foreground="green">Very good. Access granted.</span>'
+            # )
+            # self.label.show()
+            os._exit(66)
 
-	def on_delete_event(self, widget, event):
-		return True
-		# self.window.set_keep_above(True)
+    def on_delete_event(self, widget, event):
+        return True
+        # self.window.set_keep_above(True)
 
-	def on_focus_change(self, widget, event):
-		print "Focus changed."
-		return True
+    def on_focus_change(self, widget, event):
+        print("Focus changed.")
+        return True
 
-	def on_window_state_change(self, widget, event):
-		self.window.activate_focus()
-		print "Something happened."
-		return False
+    def on_window_state_change(self, widget, event):
+        self.window.activate_focus()
+        print("Something happened.")
+        return False
 
-	def on_key_press(self, widget, event):
-		keyname = gtk.gdk.keyval_name(event.keyval)
-		# print "Key %s (%d) was pressed" % (keyname, event.keyval)
-		if event.keyval > 65470 and event.keyval < 65481: # F1 through F12
-			print "Key %s (%d) was pressed" % (keyname, event.keyval)
-			# return True
-		if event.state & gtk.gdk.CONTROL_MASK:
-			print "Control was being held down"
-			# return True
-		if event.state & gtk.gdk.MOD1_MASK:
-			print "Alt was being held down"
-			# return True
-		if event.state & gtk.gdk.SHIFT_MASK:
-			print "Shift was being held down"
+    def on_key_press(self, widget, event):
+        keyname = Gdk.keyval_name(event.keyval)
+        # print "Key %s (%d) was pressed" % (keyname, event.keyval)
+        if event.keyval > 65470 and event.keyval < 65481:  # F1 through F12
+            print(("Key %s (%d) was pressed" % (keyname, event.keyval)))
+            # return True
+        if event.get_state() & Gdk.ModifierType.CONTROL_MASK:
+            print("Control was being held down")
+            # return True
+        if event.get_state() & Gdk.ModifierType.MOD1_MASK:
+            print("Alt was being held down")
+            # return True
+        if event.get_state() & Gdk.ModifierType.SHIFT_MASK:
+            print("Shift was being held down")
 
-	def scale_image(self, pixbuf, scale):
-		new_width = int(scale*pixbuf.get_width())
-		new_height = int(scale*pixbuf.get_height())
-		# print "Scaled image to: %s x %s" % (new_width, new_height)
-		return pixbuf.scale_simple(new_width, new_height, gtk.gdk.INTERP_BILINEAR)
+    def scale_image(self, pixbuf, scale):
+        new_width = int(scale * pixbuf.get_width())
+        new_height = int(scale * pixbuf.get_height())
+        # print "Scaled image to: %s x %s" % (new_width, new_height)
+        return pixbuf.scale_simple(new_width, new_height, GdkPixbuf.InterpType.BILINEAR)
 
-	def __init__(self):
+    def __init__(self):
 
-		# calculate number of screens
-		width = gtk.gdk.screen_width()
-		height = gtk.gdk.screen_height()
+        # calculate number of screens
+        width = Gdk.Screen.width()
+        height = Gdk.Screen.height()
 
-		black = gtk.gdk.color_parse("black")
+        black = Gdk.RGBA()
+        black.parse("black")
 
-		###################################
-		# black bg
-		###################################
+        ###################################
+        # black bg
+        ###################################
 
-		self.bg_window = gtk.Window(gtk.WINDOW_POPUP)
-		self.bg_window.modify_bg(gtk.STATE_NORMAL, black)
-		self.bg_window.resize(width, height)
-		self.bg_window.set_deletable(False)
-		self.bg_window.show()
+        self.bg_window = Gtk.Window.new(Gtk.WindowType.POPUP)
+        self.bg_window.override_background_color(Gtk.StateType.NORMAL, black)
+        self.bg_window.resize(width, height)
+        self.bg_window.set_deletable(False)
+        self.bg_window.show()
 
-		# monitors = self.bg_window.get_screen().get_n_monitors()
+        # monitors = self.bg_window.get_screen().get_n_monitors()
 
-		###################################
-		# window
-		###################################
+        ###################################
+        # window
+        ###################################
 
-		self.window = gtk.Window(gtk.WINDOW_POPUP)
-		self.window.set_title("Prey Lock")
-		self.window.modify_bg(gtk.STATE_NORMAL, black)
+        self.window = Gtk.Window.new(Gtk.WindowType.POPUP)
+        self.window.set_title("Prey Lock")
+        self.window.override_background_color(Gtk.StateType.NORMAL, black)
 
-		# prevents window from being closed
-		self.window.connect("delete_event", self.on_delete_event)
-		# capture keypresses
-		self.window.connect("key_press_event", self.on_key_press)
+        # prevents window from being closed
+        self.window.connect("delete_event", self.on_delete_event)
+        # capture keypresses
+        self.window.connect("key_press_event", self.on_key_press)
 
-		self.window.stick()
-		self.window.set_deletable(False)
-		# self.window.set_focus_on_map(True)
-		self.window.set_decorated(False)
-		self.window.set_border_width(0)
-		self.window.set_keep_above(True)
-		self.window.set_resizable(False)
-		# self.window.fullscreen()
+        self.window.stick()
+        self.window.set_deletable(False)
+        # self.window.set_focus_on_map(True)
+        self.window.set_decorated(False)
+        self.window.set_border_width(0)
+        self.window.set_keep_above(True)
+        self.window.set_resizable(False)
+        # self.window.fullscreen()
 
-		main_screen_width = self.window.get_screen().get_monitor_geometry(0).width
-		main_screen_height = self.window.get_screen().get_monitor_geometry(0).height
-		main_screen_middle = main_screen_width/2
+        _monitor = self.window.get_display().get_primary_monitor()
+        main_screen_width = _monitor.get_geometry().width
+        main_screen_height = _monitor.get_geometry().height
+        main_screen_middle = main_screen_width / 2
 
-		# print "Main screen size: %s x %s" % (main_screen_width, main_screen_height)
-		# print "Main screen middle: %s" % main_screen_middle
+        # print "Main screen size: %s x %s" % (main_screen_width, main_screen_height)
+        # print "Main screen middle: %s" % main_screen_middle
 
-		vbox = gtk.VBox(False, 0)
-		vbox.set_size_request(main_screen_width, main_screen_height)
-		self.window.add(vbox)
-		# vbox.show()
+        vbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
+        vbox.set_homogeneous(False)
+        vbox.set_size_request(main_screen_width, main_screen_height)
+        self.window.add(vbox)
+        # vbox.show()
 
-		###################################
-		# background color and image
-		###################################
+        ###################################
+        # background color and image
+        ###################################
 
-		image = gtk.Image()
-		script_path = sys.path[0]
-		bg_path = script_path + image_file
-		pixbuf = gtk.gdk.pixbuf_new_from_file(bg_path)
-		image_width = pixbuf.get_width()
-		image_height = pixbuf.get_height()
+        image = Gtk.Image()
+        script_path = sys.path[0]
+        bg_path = script_path + image_file
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file(bg_path)
+        image_width = pixbuf.get_width()
+        image_height = pixbuf.get_height()
 
-		# print 'Image size: %s x %s' % (image_width, image_height)
-		scale = 1
-		input_font = 16
-		error_font = 11
+        # print 'Image size: %s x %s' % (image_width, image_height)
+        scale = 1
+        input_font = 16
+        error_font = 11
 
-		if image_width > main_screen_width or image_height > main_screen_height:
-			scale = min(float(main_screen_width)/image_width, float(main_screen_height)/image_height)
-			pixbuf = scale_image(pixbuf, scale)
+        if image_width > main_screen_width or image_height > main_screen_height:
+            scale = min(
+                float(main_screen_width) / image_width,
+                float(main_screen_height) / image_height,
+            )
+            pixbuf = self.scale_image(pixbuf, scale)
 
-		elif main_screen_width > 2000:
-			scale = 2
-			pixbuf = self.scale_image(pixbuf, scale)
-			input_font -= 2
-			error_font -= 1
+        elif main_screen_width > 2000:
+            scale = 2
+            pixbuf = self.scale_image(pixbuf, scale)
+            input_font -= 2
+            error_font -= 1
 
-		image.set_from_pixbuf(pixbuf)
-		image.set_size_request(main_screen_width, main_screen_height)
-		image.show()
-		vbox.add(image)
+        image.set_from_pixbuf(pixbuf)
+        image.set_size_request(main_screen_width, main_screen_height)
+        image.show()
+        vbox.add(image)
 
-		###################################
-		# label
-		###################################
+        ###################################
+        # label
+        ###################################
 
-		self.entry = gtk.Entry(max=0)
-		self.entry.set_max_length(40)
+        self.entry = Gtk.Entry.new()
+        self.entry.set_max_length(40)
 
-		self.entry.set_inner_border(None)
-		self.entry.set_width_chars(20)
-		self.entry.set_visibility(False)
-		self.entry.set_has_frame(False)
-		self.entry.modify_base(gtk.STATE_NORMAL, gtk.gdk.color_parse("#FFFFFF"))
-		self.entry.modify_font(pango.FontDescription("sans " + str(input_font)))
-		self.entry.set_flags(gtk.CAN_FOCUS | gtk.HAS_FOCUS | gtk.HAS_GRAB | gtk.CAN_DEFAULT | gtk.SENSITIVE)
-		self.entry.connect("activate", self.enter_callback, self.entry)
-		# self.entry.show()
+        # self.entry.set_inner_border(None)  # FIXME: Ignored since Gtk 3.4
+        self.entry.set_width_chars(20)
+        self.entry.set_visibility(False)
+        self.entry.set_has_frame(False)
+        self.entry.override_background_color(
+            Gtk.StateType.NORMAL, Gdk.RGBA(red=1.0, green=1.0, blue=1.0, alpha=1.0)
+        )
+        self.entry.override_font(Pango.FontDescription("sans " + str(input_font)))
+        self.entry.set_can_focus(True)
+        self.entry.grab_focus()
+        self.entry.set_can_default(True)
+        self.entry.set_sensitive(True)
+        self.entry.set_input_purpose(Gtk.InputPurpose.PASSWORD)
 
-		input_size = 140
-		padding_left = int(input_size*scale)
-		padding_top = 5*scale
-		# print 'Padding: left %s, top %s' % (padding_left, padding_top)
+        self.entry.connect("activate", self.enter_callback, self.entry)
+        # self.entry.show()
 
-		# if image was scaled down, calculate offset for positioning elements
-		if image_height > main_screen_height:
-			padding_top = 18 - int((image_height - main_screen_height)/8)
+        input_size = 140
+        padding_left = int(input_size * scale)
+        padding_top = 5 * scale
+        # print 'Padding: left %s, top %s' % (padding_left, padding_top)
 
-		x_position = main_screen_middle-padding_left
-		y_position = -(main_screen_height/2)+padding_top
-		# print "Fixed position: %s, %s" % (x_position, y_position)
+        # if image was scaled down, calculate offset for positioning elements
+        if image_height > main_screen_height:
+            padding_top = 18 - int((image_height - main_screen_height) / 8)
 
-		fixed = gtk.Fixed()
-		fixed.put(self.entry, x_position, y_position)
-		fixed.show()
-		vbox.pack_start(fixed, False, False, 0)
+        x_position = main_screen_middle - padding_left
+        y_position = -(main_screen_height / 2) + padding_top
+        # print "Fixed position: %s, %s" % (x_position, y_position)
 
-		text = 'Invalid password. Access denied.'
-		self.label = gtk.Label()
-		self.label.set_markup('<span foreground="#b22222">'+text+'</span>');
-		self.label.modify_font(pango.FontDescription("sans " + str(error_font)))
-		# self.label.set_size_request(main_screen_width, 30)
+        fixed = Gtk.Fixed.new()
+        fixed.put(self.entry, x_position, y_position)
+        fixed.show()
+        vbox.pack_start(fixed, False, False, 0)
 
-		fixed2 = gtk.Fixed()
-		# push label down a bit, and left a bit so it remains centered
-		fixed2.put(self.label, x_position + 20, y_position + (46 * scale))
-		vbox.pack_start(fixed2, False, False, 0)
+        text = "Invalid password. Access denied."
+        self.label = Gtk.Label()
+        self.label.set_markup('<span foreground="#b22222">' + text + "</span>")
+        self.label.override_font(Pango.FontDescription("sans " + str(error_font)))
+        # self.label.set_size_request(main_screen_width, 30)
 
-		disable_XF86Switch()
+        fixed2 = Gtk.Fixed.new()
+        # push label down a bit, and left a bit so it remains centered
+        fixed2.put(self.label, x_position + 20, y_position + (46 * scale))
+        vbox.pack_start(fixed2, False, False, 0)
 
-		self.window.show_all()
-		# self.window.set_focus(self.entry)
-		gtk.gdk.keyboard_grab(fixed.window, True)
-		self.label.hide()
+        disable_XF86Switch()
+
+        self.window.show_all()
+        # self.window.set_focus(self.entry)
+        seat = self.window.get_display().get_default_seat()
+        seat.grab(
+            fixed.get_parent_window(),
+            Gdk.SeatCapabilities.KEYBOARD,
+            True,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        self.label.hide()
+
 
 original_keycodes = []
 
+
 def enable_XF86Switch():
-	import subprocess # need at least python 2.4
-	try:
-		for x,y,z in original_keycodes:
-			cmd = ['xmodmap', '-e', 'keycode %s=%s %s' % (x,y,z)]
-			subprocess.Popen(cmd)
-	except OSError, subprocess.CalledProcessError:
-		return
+    import subprocess  # need at least python 2.4
+
+    try:
+        for x, y, z in original_keycodes:
+            cmd = ["xmodmap", "-e", "keycode %s=%s %s" % (x, y, z)]
+            subprocess.Popen(cmd)
+    except (OSError, subprocess.CalledProcessError):
+        return
+
 
 def disable_XF86Switch():
-	import subprocess # need at least python 2.4
-	import re
+    import subprocess  # need at least python 2.4
+    import re
 
-	try:
-		cmd = ['xmodmap', '-pk']
-		# find all keys that allows switching to a VT
-		p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-		output, serror = p.communicate()
-		matched = []
+    try:
+        cmd = ["xmodmap", "-pk"]
+        # find all keys that allows switching to a VT
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        output, serror = p.communicate()
+        matched = []
 
-		# retrieve the keycode and its value from xmodmap output
-		for line in output.split('\n'):
-			if re.search('XF86Switch_VT', line):
-				items = line.split()
-				keycode = items[0]
-				keysym  = items[1]
-				keysym2 = items[7]
-				keyname = items[2][1:-1]
-				matched.append((keycode, keyname))
-				original_keycodes.append((keycode, keysym, keysym2))
+        # retrieve the keycode and its value from xmodmap output
+        for line in output.split("\n"):
+            if re.search("XF86Switch_VT", line):
+                items = line.split()
+                keycode = items[0]
+                keysym = items[1]
+                keysym2 = items[7]
+                keyname = items[2][1:-1]
+                matched.append((keycode, keyname))
+                original_keycodes.append((keycode, keysym, keysym2))
 
-		# disable all key that allow to switch to a VT
-		for k,v in matched:
-			cmd = ['xmodmap', '-e', 'keycode %s=%s' % (k,v)]
-			subprocess.Popen(cmd)
+        # disable all key that allow to switch to a VT
+        for k, v in matched:
+            cmd = ["xmodmap", "-e", "keycode %s=%s" % (k, v)]
+            subprocess.Popen(cmd)
 
-	except IndexError:
-		print "Couldn't parse Xmodmap list."
+    except IndexError:
+        print("Couldn't parse Xmodmap list.")
 
-	except OSError, subprocess.CalledProcessError:
-		# print "Xmodmap not found"
-		# do nothing if xmodmap is not found or return an error
-		return
+    except (OSError, subprocess.CalledProcessError):
+        # print "Xmodmap not found"
+        # do nothing if xmodmap is not found or return an error
+        return
+
 
 if __name__ == "__main__":
 
-	if len(sys.argv) < 2 or len(sys.argv[1]) != 32:
-		print "You need to pass an MD5 hexdigested string."
-		sys.exit(67)
-	else:
-		passwd = sys.argv[1]
+    if len(sys.argv) < 2 or len(sys.argv[1]) != 32:
+        print("You need to pass an MD5 hexdigested string.")
+        sys.exit(67)
+    else:
+        passwd = sys.argv[1]
 
-	write("Process PID: %d" % os.getpid())
-	lock = Lock()
-	gtk.main()
+    write("Process PID: %d" % os.getpid())
+    lock = Lock()
+    Gtk.main()

--- a/lib/conf/gui/linux/prey-config.py
+++ b/lib/conf/gui/linux/prey-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ################################################
 # Prey Configurator for Linux
 # By Tomas Pollak
@@ -12,21 +12,21 @@
 # base includes
 ################################################
 
-APP_NAME = 'prey-config'
-LANG_PATH = 'lang'
+APP_NAME = "prey-config"
+LANG_PATH = "lang"
 
 import sys
-import pygtk
-import gtk
 import os
 import re
 import json
-import locale
 import gettext
 import shlex
-from subprocess import Popen, call, PIPE, STDOUT
+from subprocess import Popen, PIPE, STDOUT
 
-pygtk.require("2.0")
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+from gi.repository import Gdk
 
 # locale.setlocale(locale.LC_ALL, '')
 # locale.bindtextdomain(app_name, lang_path)
@@ -38,331 +38,374 @@ _ = gettext.gettext
 # vars and such
 ################################################
 
-FORCE_CONFIG = len(sys.argv) > 1 and (sys.argv[1] == '-f' or sys.argv[1] == '--force')
+FORCE_CONFIG = len(sys.argv) > 1 and (sys.argv[1] == "-f" or sys.argv[1] == "--force")
 
-OUT = STDOUT # None
+OUT = STDOUT  # None
 
 SCRIPT_PATH = os.sys.path[0]
-PACKAGE_PATH = SCRIPT_PATH + '/../../../..'
-PREY_BIN = PACKAGE_PATH + '/bin/prey'
-PREY_CONFIG = PREY_BIN + ' config'
+PACKAGE_PATH = SCRIPT_PATH + "/../../../.."
+PREY_BIN = PACKAGE_PATH + "/bin/prey"
+PREY_CONFIG = PREY_BIN + " config"
 
-PACKAGE_JSON = open(PACKAGE_PATH + '/package.json', 'r')
+PACKAGE_JSON = open(PACKAGE_PATH + "/package.json", "r")
 PACKAGE_INFO = json.loads(PACKAGE_JSON.read())
-VERSION = PACKAGE_INFO['version']
+VERSION = PACKAGE_INFO["version"]
 
-PAGES = ['control_panel_options', 'new_user', 'existing_user', 'existing_device']
+PAGES = ["control_panel_options", "new_user", "existing_user", "existing_device"]
 EMAIL_REGEX = "^.+\\@(\\[?)[a-zA-Z0-9\\-\\.]+\\.([a-zA-Z]{2,7}|[0-9]{1,3})(\\]?)$"
+
 
 class PreyConfigurator(object):
 
-  ################################################
-  # helper functions
-  ################################################
+    ################################################
+    # helper functions
+    ################################################
 
-  def get(self, name):
-    return self.root.get_object(name)
+    def get(self, name):
+        return self.root.get_object(name)
 
-  def text(self, name):
-    return self.get(name).get_text()
+    def text(self, name):
+        return self.get(name).get_text()
 
-  ################################################
-  # validations
-  ################################################
+    ################################################
+    # validations
+    ################################################
 
-  def valid_email_regex(self, string):
-    if len(string) > 7:
-      if re.match(EMAIL_REGEX, string) != None:
+    def valid_email_regex(self, string):
+        if len(string) > 7:
+            if re.match(EMAIL_REGEX, string) is not None:
+                return True
+        return False
+
+    def validate_email(self, email_field):
+        if not self.valid_email_regex(self.text(email_field)):
+            self.show_alert(
+                _("Invalid email"),
+                _("Please make sure the email address you typed is valid."),
+            )
+            return False
+
         return True
-    return False
 
-  def validate_email(self, email_field):
-    if not self.valid_email_regex(self.text(email_field)):
-      self.show_alert(_("Invalid email"), _("Please make sure the email address you typed is valid."))
-      return False
+    def validate_password(self, password_field):
+        if len(self.text(password_field)) < 6:
+            self.show_alert(
+                _("Bad password"), _("Password should contain at least 6 chars.")
+            )
+            return False
 
-    return True
+        return True
 
-  def validate_password(self, password_field):
-    if len(self.text(password_field)) < 6:
-      self.show_alert(_("Bad password"), _("Password should contain at least 6 chars."))
-      return False
+    def validate_existing_user_fields(self):
+        if self.text("existing_email") == "":
+            self.show_alert(_("Empty email!"), _("Please type in your email."))
+            return False
+        if self.text("existing_password") == "":
+            self.show_alert(_("Empty password!"), _("Please type in your password."))
+            return False
 
-    return True
+        return True
 
-  def validate_existing_user_fields(self):
-    if self.text('existing_email') == '':
-      self.show_alert(_("Empty email!"), _("Please type in your email."))
-      return False
-    if self.text('existing_password') == '':
-      self.show_alert(_("Empty password!"), _("Please type in your password."))
-      return False
+    def validate_new_user_fields(self):
+        if self.text("user_name") == "":
+            self.show_alert(_("Empty name!"), _("Please type in your name."))
+            return False
+        if self.text("email") == "":
+            self.show_alert(_("Empty email!"), _("Please type in your email."))
+            return False
+        if self.text("password") == "":
+            self.show_alert(_("Empty password!"), _("Please type in your password."))
+            return False
+        elif self.text("password") != self.text("password_confirm"):
+            self.show_alert(
+                _("Passwords don't match"), _("Please make sure both passwords match.")
+            )
+            return False
+        if not self.get("check_terms_conds").get_active():
+            self.show_alert(
+                _("Error"),
+                _(
+                    "You need to accept the Terms & Conditions and Privacy Policy to continue"
+                ),
+            )
+            return False
+        if not self.get("check_age").get_active():
+            self.show_alert(
+                _("Error"), _("You must be older than 16 years old to use Prey")
+            )
+            return False
+        return True
 
-    return True
+    ################################################
+    # dialogs
+    ################################################
 
-  def validate_new_user_fields(self):
-    if self.text('user_name') == '':
-      self.show_alert(_("Empty name!"), _("Please type in your name."))
-      return False
-    if self.text('email') == '':
-      self.show_alert(_("Empty email!"), _("Please type in your email."))
-      return False
-    if self.text('password') == '':
-      self.show_alert(_("Empty password!"), _("Please type in your password."))
-      return False
-    elif self.text('password') != self.text('password_confirm'):
-      self.show_alert(_("Passwords don't match"), _("Please make sure both passwords match."))
-      return False
-    if not self.get('check_terms_conds').get_active():
-      self.show_alert(_("Error"), _("You need to accept the Terms & Conditions and Privacy Policy to continue"))
-      return False
-    if not self.get('check_age').get_active():
-      self.show_alert(_("Error"), _("You must be older than 16 years old to use Prey"))
-      return False
-    return True
+    def show_alert(self, title, message, quit=False):
+        dialog = Gtk.MessageDialog(
+            parent=None,
+            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            type=Gtk.MessageType.INFO,
+            buttons=Gtk.ButtonsType.OK,
+            message_format=message,
+        )
+        dialog.set_title(title)
+        if quit is True:
+            dialog.connect("response", lambda dialog, response: Gtk.main_quit())
+        else:
+            dialog.connect("response", lambda dialog, response: dialog.destroy())
+        self.center_dialog(dialog)
+        dialog.show()
 
-  ################################################
-  # dialogs
-  ################################################
+    def show_about(self):
+        dialog = self.get("about_prey_config")
+        self.center_dialog(dialog)
+        dialog.show()
 
-  def show_alert(self, title, message, quit = False):
-    dialog = gtk.MessageDialog(
-      parent         = None,
-      flags          = gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
-      type           = gtk.MESSAGE_INFO,
-      buttons        = gtk.BUTTONS_OK,
-      message_format = message)
-    dialog.set_title(title)
-    if quit == True:
-      dialog.connect('response', lambda dialog, response: gtk.main_quit())
-    else:
-      dialog.connect('response', lambda dialog, response: dialog.destroy())
-    self.center_dialog(dialog)
-    dialog.show()
+    def close_about(self, dialog, response):
+        dialog.hide()
 
-  def show_about(self):
-    dialog = self.get('about_prey_config')
-    self.center_dialog(dialog)
-    dialog.show()
+    def center_dialog(self, dialog):
+        if "window" in self.__dict__:
+            dialog.set_transient_for(self.window)
+        dialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
 
-  def close_about(self, dialog, response):
-    dialog.hide()
+    ################################################
+    # window and widget management
+    ################################################
 
-  def center_dialog(self, dialog):
-    if 'window' in self.__dict__:
-      dialog.set_transient_for(self.window)
-    dialog.set_position(gtk.WIN_POS_CENTER_ON_PARENT)
+    def get_page_name(self):
+        return PAGES[self.pages.get_current_page()]
 
-  ################################################
-  # window and widget management
-  ################################################
+    def toggle_pg3_next_apply(self, button):
+        button_next = self.get("button_next")
+        button_apply = self.get("button_apply")
 
-  def get_page_name(self):
-    return PAGES[self.pages.get_current_page()]
+        if self.get("use_existing_device").get_active() is False:
+            button_next.hide()
+            button_apply.show()
+            button_apply.grab_default()
+        else:
+            button_apply.hide()
+            button_next.show()
+            button_next.grab_default()
 
-  def toggle_pg3_next_apply(self, button):
-    button_next = self.get('button_next')
-    button_apply = self.get('button_apply')
+    def next_page(self, button):
+        page_name = self.get_page_name()
+        increment = 1
 
-    if self.get('use_existing_device').get_active() == False:
-      button_next.hide()
-      button_apply.show()
-      button_apply.grab_default()
-    else:
-      button_apply.hide()
-      button_next.show()
-      button_next.grab_default()
+        if (
+            page_name == "control_panel_options"
+            and self.get("new_user_option").get_active() is False
+        ):
+            increment = 2
 
-  def next_page(self, button):
-    page_name = self.get_page_name()
-    increment = 1
+        self.pages.set_current_page(self.pages.get_current_page() + increment)
+        self.toggle_buttons(button, None, 1)
 
-    if page_name == 'control_panel_options' and \
-      self.get('new_user_option').get_active() == False:
-        increment = 2
+    def prev_page(self, button):
+        page_name = self.get_page_name()
+        decrement = 1
 
-    self.pages.set_current_page(self.pages.get_current_page() + increment)
-    self.toggle_buttons(button, None, 1)
+        if page_name == "existing_user":
+            decrement = 2
+        # elif page_name == 'standalone_options':
+        # decrement = 5
 
-  def prev_page(self, button):
-    page_name = self.get_page_name()
-    decrement = 1
+        if self.pages.get_current_page() != 0:
+            self.pages.set_current_page(self.pages.get_current_page() - decrement)
 
-    if page_name == 'existing_user':
-      decrement = 2
-    # elif page_name == 'standalone_options':
-      # decrement = 5
+        self.toggle_buttons(button, None, 1)
 
-    if self.pages.get_current_page() != 0:
-      self.pages.set_current_page(self.pages.get_current_page() - decrement)
+    def toggle_buttons(self, button, tab, tab_number):
 
-    self.toggle_buttons(button, None, 1)
+        button_prev = self.get("button_prev")
+        button_next = self.get("button_next")
+        button_apply = self.get("button_apply")
 
-  def toggle_buttons(self, button, tab, tab_number):
+        if self.get_page_name() == "control_panel_options":
+            button_prev.hide()
+            button_apply.hide()
+            button_next.show()
+            button_next.grab_default()
+        else:
+            button_prev.show()
+            button_next.hide()
+            button_apply.show()
+            button_apply.grab_default()
 
-    button_prev  = self.get('button_prev')
-    button_next  = self.get('button_next')
-    button_apply = self.get('button_apply')
+    def set_default_action(self, button, ctrl):
+        button_cancel = self.get("button_cancel")
+        cancel_has_default = button_cancel.flags() & Gtk.HAS_DEFAULT
+        button_prev = self.get("button_prev")
+        prev_has_default = button_prev.flags() & Gtk.HAS_DEFAULT
+        button_next = self.get("button_next")
+        button_apply = self.get("button_apply")
 
-    if self.get_page_name() == 'control_panel_options':
-      button_prev.hide()
-      button_apply.hide()
-      button_next.show()
-      button_next.grab_default()
-    else:
-      button_prev.show()
-      button_next.hide()
-      button_apply.show()
-      button_apply.grab_default()
+        if not cancel_has_default and not prev_has_default:
+            if button_next.flags() & Gtk.VISIBLE:
+                button_next.grab_default()
+            else:
+                button_apply.grab_default()
 
+    # ensure the widget focused is visible in the scroll window
+    def ensure_visible(self, widget, event):
+        widget_name = widget.get_name()
+        internal_height = self.get("control_panel_options").get_size()[1]
+        widget_posn = widget.allocation.y
+        widget_height = widget.allocation.height
+        return True
 
-  def set_default_action(self,button,ctrl):
-    button_cancel = self.get('button_cancel')
-    cancel_has_default = button_cancel.flags() & gtk.HAS_DEFAULT
-    button_prev = self.get('button_prev')
-    prev_has_default = button_prev.flags() & gtk.HAS_DEFAULT
-    button_next = self.get('button_next')
-    button_apply = self.get('button_apply')
+    # show about dialog on F1 keypress
+    def key_pressed(self, widget, event):
+        if (
+            (event.keyval == Gdk.KEY_F1)
+            and (event.get_state() & Gdk.ModifierType.CONTROL_MASK) == 0
+            and (event.get_state() & Gdk.ModifierType.SHIFT_MASK) == 0
+        ):
+            self.show_about()
+            return True
 
-    if not cancel_has_default and not prev_has_default:
-      if button_next.flags() & gtk.VISIBLE:
-        button_next.grab_default()
-      else:
-        button_apply.grab_default()
+        return False
 
-  # ensure the widget focused is visible in the scroll window
-  def ensure_visible(self, widget, event):
-    widget_name = widget.get_name()
-    internal_height = self.get('control_panel_options').get_size()[1]
-    widget_posn = widget.allocation.y
-    widget_height = widget.allocation.height
-    return True
+    ################################################
+    # setting settings
+    ################################################
 
-  # show about dialog on F1 keypress
-  def key_pressed(self, widget, event):
-    if (event.keyval == gtk.keysyms.F1) \
-    and (event.state & gtk.gdk.CONTROL_MASK) == 0 \
-    and (event.state & gtk.gdk.SHIFT_MASK) == 0:
-      self.show_about()
-      return True
+    def apply_settings(self, button):
+        self.get("button_apply").set_label(_("Saving..."))
 
-    return False
+        page_name = self.get_page_name()
+        if page_name == "new_user":
+            if self.validate_new_user_fields():
+                self.create_user()
+        elif page_name == "existing_user":
+            if self.validate_existing_user_fields():
+                self.get_existing_user(False)
 
-  ################################################
-  # setting settings
-  ################################################
+        self.get("button_apply").set_label("gtk-apply")
 
-  def apply_settings(self, button):
-    self.get('button_apply').set_label(_("Saving..."))
+    def client_configured(self):
+        self.call_prey_config("account verify", "--current")
+        return self.result == 0
 
-    page_name = self.get_page_name()
-    if page_name == 'new_user':
-      if self.validate_new_user_fields():
-        self.create_user()
-    elif page_name == "existing_user":
-      if self.validate_existing_user_fields():
-        self.get_existing_user(False)
+    def create_user(self):
+        name = self.text("user_name")
+        email = self.text("email")
+        password = self.text("password")
+        check_terms = self.get("check_terms_conds").get_active()
+        check_age = self.get("check_age").get_active()
+        terms = "no"
+        age = "no"
 
-    self.get('button_apply').set_label('gtk-apply')
+        if check_terms is True:
+            terms = "yes"
+        if check_age is True:
+            age = "yes"
 
-  def client_configured(self):
-    self.call_prey_config('account verify', '--current')
-    return self.result == 0
+        password = re.escape(password)
 
-  def create_user(self):
-    name        = self.text('user_name')
-    email       = self.text('email')
-    password    = self.text('password')
-    check_terms = self.get('check_terms_conds').get_active()
-    check_age   = self.get('check_age').get_active()
-    terms       = 'no'
-    age         = 'no'
+        self.call_prey_config(
+            "account signup",
+            '-n "'
+            + name
+            + '" -e "'
+            + email
+            + '" -p '
+            + password
+            + ' -t "'
+            + terms
+            + '" -a "'
+            + age
+            + '"',
+        )
+        self.error_or_exit()
 
-    if check_terms == True : terms = 'yes'
-    if check_age == True : age = 'yes'
+    def get_existing_user(self, show_devices):
+        email = self.text("existing_email")
+        password = self.text("existing_password")
+        password = re.escape(password)
 
-    password = re.escape(password)
+        self.call_prey_config("account authorize", '-e "' + email + '" -p ' + password)
+        self.error_or_exit()
 
-    self.call_prey_config('account signup', '-n "' + name + '" -e "' + email + '" -p ' + password + ' -t "' + terms + '" -a "' + age +'"')
-    self.error_or_exit()
+    def call_prey_config(self, action, opts):
+        return self.run_command(PREY_CONFIG + " " + action + " " + opts)
 
-  def get_existing_user(self, show_devices):
-    email    = self.text('existing_email')
-    password = self.text('existing_password')
-    password = re.escape(password)
+    def run_prey(self):
+        return self.run_command(PREY_BIN)
 
-    self.call_prey_config('account authorize', '-e "' + email + '" -p ' + password)
-    self.error_or_exit()
+    def run_command(self, cmd):
+        args = shlex.split(cmd)
+        proc = Popen(args, stdout=PIPE, shell=False)
+        self.out = proc.communicate()[0]
+        self.result = proc.returncode
+        return proc
 
-  def call_prey_config(self, action, opts):
-    return self.run_command(PREY_CONFIG + ' ' + action + ' ' + opts)
+    def parse_error(self, line):
+        if line.find("been taken") != -1:
+            return "Email has been taken. Seems you already signed up!"
+        elif line.find("Unexpected status code: 401") != -1:
+            return "Invalid account credentials. Please try again."
 
-  def run_prey(self):
-    return self.run_command(PREY_BIN)
+        return line
 
-  def run_command(self, cmd):
-    args = shlex.split(cmd)
-    proc = Popen(args, stdout=PIPE, shell=False)
-    self.out = proc.communicate()[0]
-    self.result = proc.returncode
-    return proc
+    def error_or_exit(self):
+        if self.result == 0:
+            return self.exit_ok()
+        #      self.run_prey()
+        #      if self.result == 0:
+        #        self.exit_ok()
+        #      else:
+        #        self.show_alert('Error', 'Something went wrong while running Prey. Please check the logfile for details.')
+        else:
+            lines = self.out.strip()
+            message = self.parse_error(lines)
+            self.show_error(message)
 
-  def parse_error(self, line):
-    if line.find('been taken') != -1:
-      return 'Email has been taken. Seems you already signed up!'
-    elif line.find('Unexpected status code: 401') != -1:
-      return 'Invalid account credentials. Please try again.'
+    def show_error(self, message):
+        self.show_alert(_("Hold on!"), _(message), False)
 
-    return line
+    def exit_ok(self):
+        self.show_alert(
+            _("Success"),
+            _(
+                "Sweet! Your computer is now protected by Prey. To try it out or to start tracking it, please visit preyproject.com."
+            ),
+            True,
+        )
 
-  def error_or_exit(self):
-    if self.result == 0:
-      return self.exit_ok()
-#      self.run_prey()
-#      if self.result == 0:
-#        self.exit_ok()
-#      else:
-#        self.show_alert('Error', 'Something went wrong while running Prey. Please check the logfile for details.')
-    else:
-      lines = self.out.strip()
-      message = self.parse_error(lines)
-      self.show_error(message)
+    def __init__(self):
+        if not FORCE_CONFIG and self.client_configured():
+            return self.exit_ok()
 
-  def show_error(self, message):
-    self.show_alert(_('Hold on!'), _(message), False)
+        builder = Gtk.Builder()
+        builder.set_translation_domain(APP_NAME)
+        builder.add_from_file(SCRIPT_PATH + "/prey-config.glade")
+        builder.connect_signals(
+            {
+                "on_window_destroy": Gtk.main_quit,
+                "prev_page": self.prev_page,
+                "next_page": self.next_page,
+                "toggle_buttons": self.toggle_buttons,
+                "apply_settings": self.apply_settings,
+                "toggle_pg3_next_apply": self.toggle_pg3_next_apply,
+                "set_default_action": self.set_default_action,
+                "ensure_visible": self.ensure_visible,
+                "key_pressed": self.key_pressed,
+                "close_about": self.close_about,
+            }
+        )
 
-  def exit_ok(self):
-    self.show_alert(_('Success'), _('Sweet! Your computer is now protected by Prey. To try it out or to start tracking it, please visit preyproject.com.'), True)
+        self.window = builder.get_object("window")
+        self.window.set_title(self.window.get_title() + " (v" + VERSION + ")")
+        # self.window.get_settings().set_string_property('gtk-font-name', 'sans normal 11','');
+        self.pages = builder.get_object("reporting_mode_tabs")
+        self.root = builder
 
-  def __init__(self):
-    if not FORCE_CONFIG and self.client_configured():
-      return self.exit_ok()
+        about = self.get("about_prey_config")
+        about.set_version(VERSION)
 
-    builder = gtk.Builder()
-    builder.set_translation_domain(APP_NAME)
-    builder.add_from_file(SCRIPT_PATH + "/prey-config.glade")
-    builder.connect_signals({
-      "on_window_destroy"     : gtk.main_quit,
-      "prev_page"             : self.prev_page,
-      "next_page"             : self.next_page,
-      "toggle_buttons"        : self.toggle_buttons,
-      "apply_settings"        : self.apply_settings,
-      "toggle_pg3_next_apply" : self.toggle_pg3_next_apply,
-      "set_default_action"    : self.set_default_action,
-      "ensure_visible"        : self.ensure_visible,
-      "key_pressed"           : self.key_pressed,
-      "close_about"           : self.close_about
-    })
-
-    self.window = builder.get_object("window")
-    self.window.set_title(self.window.get_title() + " (v" + VERSION + ")")
-    # self.window.get_settings().set_string_property('gtk-font-name', 'sans normal 11','');
-    self.pages = builder.get_object("reporting_mode_tabs")
-    self.root = builder
-
-    about = self.get('about_prey_config')
-    about.set_version(VERSION)
 
 if __name__ == "__main__":
-  app = PreyConfigurator()
-  gtk.main()
+    app = PreyConfigurator()
+    Gtk.main()


### PR DESCRIPTION
Python 2 is no longer supported (#453), and Gtk 2 is not recommended. I only have a Linux machine, so I only updated the Linux scripts and not the Mac ones.

I haven't tested the minimum Python 3 version, but I would expect the scripts to work on Python 3.5 and later. The minimum Gtk version is 3.20. This would mean Debian Jessie and earlier are not supported.

The updated code emits some DeprecationWarnings. These are mostly a consequence of Gtk 3.0's insistence on CSS-defined styling instead of styling defined in code. There is also a DeprecationWarning relating to `prey-lock`'s use of `Gdk.Screen.width`. That has implications for multiple-screen setups, which I can't test right now, so it's unchanged.

I found two bugs while testing that existed with python 2 and 3. Exiting out of an alert with a reply is not reliable, and there is some overlapping text in `prey-config.py`. 