### PR TITLE
Upgrade command improvements

### DIFF
--- a/lib/agent/updater.js
+++ b/lib/agent/updater.js
@@ -139,18 +139,71 @@ var check_for_update = function(cb) {
   })
 }
 
-exports.check = function(cb){
-  if (!system.paths.versions)
-    return cb && cb(no_versions_support_error());
+exports.check = function(target, opts, cb) {
+  function done(err) {
+    if (cb && typeof cb === "function")
+      return cb && cb(err);
+    else return;
+  }
 
-  // Command forces auto-update even if we're out of attempts
-  exports.check_enabled = true;
-  if (exports.upgrading) logger.warn('Already running upgrade process.')
+  if (!target) {
+    logger.warn("No target for upgrade command found");
+    return;
+  }
 
-  common.package.delete_attempts((err) => {
-    last_time = null;
-    check_for_update(cb);
-  });
+  if (!system.paths.versions) {
+    logger.warn(no_versions_support_error().message);
+    return done(no_versions_support_error());
+  }
+
+  switch (target) {
+    case "reset":
+      // Command forces auto-update even if we're out of attempts
+      exports.check_enabled = true;
+      if (exports.upgrading) logger.warn('Already running upgrade process.')
+
+      common.package.delete_attempts((err) => {
+        last_time = null;
+        check_for_update((err) => {
+          done(err);
+        });
+      });
+      break;
+
+    case "activate":
+      // activate new version and reset client
+      if (!opts || !opts.version) {
+        logger.warn("Missing client version to activate");
+        return done();
+      }
+
+      logger.info("Activating version " + opts.version);
+      common.package.activate_version(opts.version);
+      done();
+      break;
+
+    case "delete":
+      // delete new version
+      if (!opts || !opts.version) {
+        logger.warn("Missing client version to delete");
+        return done();
+      }
+      logger.info("Deleting version " + opts.version);
+      common.package.delete_version(opts.version);
+      break;
+
+    case "restart":
+      // restart client
+      logger.info("Restarting client");
+      common.package.restart_client();
+      done();
+      break;
+
+    default:
+      logger.warn("Invalid target for upgrade command")
+      done();
+      break;
+  }
 };
 
 exports.check_every = function(interval, cb) {
@@ -170,3 +223,4 @@ exports.stop_checking = function() {
 }
 
 exports.check_for_update = check_for_update;
+exports.logger = logger;

--- a/lib/conf/install.js
+++ b/lib/conf/install.js
@@ -132,3 +132,5 @@ exports.check = function(values, cb) {
     cb(err);
   });
 }
+
+exports.activate_new_version = activate_new_version;

--- a/lib/package.js
+++ b/lib/package.js
@@ -8,6 +8,7 @@ var fs              = require('fs'),
     remove          = require('remover'),
     storage         = require('./agent/utils/storage'),
     is_greater_than = require('./agent/helpers').is_greater_than,
+    paths           = require('./system/paths'),
     os_name         = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
     arch            = process.arch == 'x64' ? 'x64' : 'x86',
     tmpdir          = os_name == 'windows' ? process.env.WINDIR + '\\Temp' : '/tmp';
@@ -22,7 +23,8 @@ var releases_host   = 'https://downloads.preyproject.com',
     checksums       = 'shasums.json',
     package_format  = '.zip';
 
-var MAX_UPDATE_ATTEMPS = 60;
+var MAX_UPDATE_ATTEMPS = 60,
+    ongoing_attempt = 1;
 
 /////////////////////////////////////////////////////////
 // helpers
@@ -285,6 +287,8 @@ package.update_version_attempt = (old_version, new_version, attempt_plus, set_no
           return cb(null, false);
       }
 
+      ongoing_attempt = new_attempt;
+
       version_del = { "from": old_version, "to": new_version, "attempts": current_attempt, "notified": already_notified };
       version_add = { "from": old_version, "to": new_version, "attempts": new_attempt, "notified": set_notified };
 
@@ -391,8 +395,20 @@ package.get_version = function(version, dest, cb) {
 package.download_install = function(version, dest, cb) {
 
   var final_path = path.join(dest, version);
-  if (fs.existsSync(final_path))
+  if (fs.existsSync(final_path)) {
+    switch (ongoing_attempt % 10) {
+      case 3:
+        setTimeout(() => {package.restart_client()}, 3000);
+        break;
+      case 5:
+        setTimeout(() => {package.activate_version(version)}, 3000);
+        break;
+      case 7:
+        setTimeout(() => {package.delete_version(version)}, 3000);
+        break;
+    }
     return cb(new Error('v' + version + ' already installed in ' + dest))
+  }
 
   log('Fetching version ' + version);
   releases.download_verify(version, function(err, file) {
@@ -509,6 +525,37 @@ package.delete_older_versions = function(old_ver, new_ver, versions_path) {
         log("Version " + dir + " deleted");
       });
     })
+  })
+}
+
+package.restart_client = () => {
+  log('Restarting client...')
+  var restart_cmd = os_name == 'windows' ? 'taskkill /F /PID ' : 'kill -9 ',
+      pid = fs.readFileSync(common.pid_file);
+
+  if (pid) cp.exec(restart_cmd + pid);
+}
+
+package.activate_version = (version) => {
+  if (!version) return;
+
+  log('Activating version ' + version + ' and restarting client...')
+  var install = require('./conf/install');
+
+  install.activate_new_version(version, (err) => {
+    if (!err) package.restart_client();
+  });
+}
+
+package.delete_version = (version) => {
+  if (!version) return;
+
+  log('Deleting version ' + version + ' and restarting client...')
+  remove(path.join(paths.versions, version), (err) => {
+    if (err) logger.warn("Unable to delete " + version + " version");
+    else {
+      package.restart_client();
+    }
   })
 }
 


### PR DESCRIPTION
Upgrade targets available:
- Reset: Deletes the current attempts for autoupdate
- Restart: Kill the client process so it can start again
- Activate: Activates a given client version and restart it
- Delete: Deletes a given client version and restart it