### PR TITLE
Manage encryption status info error

### DIFF
--- a/lib/agent/providers/encryption-keys/index.js
+++ b/lib/agent/providers/encryption-keys/index.js
@@ -19,6 +19,7 @@ module.exports.get_encryption_keys = function(cb) {
   logger.info("Getting encryption keys");
   system.get_as_admin_user('recoveryKeys', (err, info) => {
     if (err) return cb(err);
+    if (!Array.isArray(info)) return cb(new Error("Invalid encryption keys information"));
 
     // Schedule another keys fetch if there's at least one disk encrypted.
     processing = false;

--- a/lib/agent/providers/encryption-status/index.js
+++ b/lib/agent/providers/encryption-status/index.js
@@ -19,6 +19,7 @@ module.exports.get_encryption_status = function(cb) {
   logger.info("Getting encryption status");
   system.get_as_admin_user('encryptStatus', (err, info) => {
     if (err) return cb(err);
+    if (!Array.isArray(info)) return cb(new Error("Invalid encryption status information"));
 
     // Schedule another status fetch if there's at least one disk encrypting or decrypting.
     processing = false;

--- a/test/lib/agent/providers/encryption-keys.js
+++ b/test/lib/agent/providers/encryption-keys.js
@@ -97,6 +97,28 @@ describe('Encryption keys', () => {
         });
       })
     })
+
+    describe('when the output is invalid', () => {
+      var wrong_keys = '{"err": null, "output": false}'
+
+      before(() => {
+        invalid_keys_stub = sinon.stub(needle, 'post').callsFake((url, data, opts, cb) => {
+          cb(null, null, wrong_keys)
+        });
+      })
+
+      after(() => {
+        invalid_keys_stub.restore();
+      })
+
+      it('returns an error', (done) => {
+        provider_keys.get_encryption_keys(function(err, obj) {
+          should.exist(err);
+          err.message.should.containEql('Invalid encryption keys information');
+          done();
+        });
+      })
+    })
   })
 })
 

--- a/test/lib/agent/providers/encryption-status.js
+++ b/test/lib/agent/providers/encryption-status.js
@@ -98,6 +98,28 @@ describe('Encryption status', () => {
         });
       })
     })
+
+    describe('when the output is invalid', () => {
+      var wrong_status = '{"err": null, "output": false}'
+
+      before(() => {
+        invalid_status_stub = sinon.stub(needle, 'post').callsFake((url, data, opts, cb) => {
+          cb(null, null, wrong_status)
+        });
+      })
+
+      after(() => {
+        invalid_status_stub.restore();
+      })
+
+      it('returns an error', (done) => {
+        provider.get_encryption_status(function(err, obj) {
+          should.exist(err);
+          err.message.should.containEql('Invalid encryption status information');
+          done();
+        });
+      })
+    })
   })
 })
 


### PR DESCRIPTION
Solve issue when the encryption status info has the wrong format, this causes a client critical error