### PR TITLE
Fix panel mac native accuracy location

### DIFF
--- a/lib/agent/providers/geo/darwin/index.js
+++ b/lib/agent/providers/geo/darwin/index.js
@@ -15,7 +15,7 @@ exports.get_location = function(cb) {
         if (err || (data && data.includes('error'))) return cb(new Error('Unable to get native location'));
         let response;
         try {
-          if(data.hasProperty('accuracy')) {
+          if(data.hasOwnProperty('accuracy')) {
             data.accuracy = parseFloat(data.accuracy).toFixed(6);
           }
           response = JSON.parse(data);

--- a/lib/agent/providers/geo/darwin/index.js
+++ b/lib/agent/providers/geo/darwin/index.js
@@ -15,6 +15,9 @@ exports.get_location = function(cb) {
         if (err || (data && data.includes('error'))) return cb(new Error('Unable to get native location'));
         let response;
         try {
+          if(data.hasProperty('accuracy')) {
+            data.accuracy = parseFloat(data.accuracy).toFixed(6);
+          }
           response = JSON.parse(data);
           return cb(null, response)
         } catch (err) {

--- a/lib/agent/providers/geo/darwin/index.js
+++ b/lib/agent/providers/geo/darwin/index.js
@@ -15,10 +15,9 @@ exports.get_location = function(cb) {
         if (err || (data && data.includes('error'))) return cb(new Error('Unable to get native location'));
         let response;
         try {
-          if(data.hasOwnProperty('accuracy')) {
-            data.accuracy = parseFloat(data.accuracy).toFixed(6);
-          }
           response = JSON.parse(data);
+          if(response.hasOwnProperty('accuracy')) 
+            response.accuracy = parseFloat(response.accuracy).toFixed(6);
           return cb(null, response)
         } catch (err) {
           return cb(new Error(err.message))


### PR DESCRIPTION
This is the fix for mac native accuracy when it gives too many digits after dot in that float number.