### PR TITLE
Fix triggers action

### DIFF
--- a/lib/agent/actions/triggers/index.js
+++ b/lib/agent/actions/triggers/index.js
@@ -57,7 +57,7 @@ function done(id, err, cb) {
 }
 
 function send_response(status, id_list) {
-  logger.info(
+  logger.debug(
     'sending ' +
       status +
       ' w/ code ' +
@@ -516,8 +516,8 @@ exports.sync = (id, err, triggers, stored, cb) => {
     triggers = stored;
   }
 
-  // logger.debug('retrieved triggers: ' + JSON.stringify(triggers));
-  // logger.info('stored triggers: ' + JSON.stringify(stored));
+  logger.debug('retrieved triggers: ' + JSON.stringify(triggers));
+  logger.debug('stored triggers: ' + JSON.stringify(stored));
 
   if (triggers.length == 0) {
     delete_all_triggers(id, cb); // delete all triggers in local db
@@ -526,7 +526,7 @@ exports.sync = (id, err, triggers, stored, cb) => {
   current_triggers = assign_active_triggers(stored, triggers); // only active triggers
   stored = delete_obsolete_triggers(stored, triggers); // will remove stored triggers that were deleted in control panel
 
-  logger.info('current triggers: ' + JSON.stringify(current_triggers));
+  logger.debug('current triggers: ' + JSON.stringify(current_triggers));
 
   exports.cancel_all();
   event_triggers = {};
@@ -538,7 +538,7 @@ exports.sync = (id, err, triggers, stored, cb) => {
 
   // iterate over only active and filtered triggers
   current_triggers.forEach((trigger, index) => {
-    logger.info('saving stored trigger ID: ' + trigger.id);
+    logger.debug('saving stored trigger ID: ' + trigger.id);
 
     if (typeof trigger.automations_events == 'string') {
       try {
@@ -658,15 +658,15 @@ exports.sync = (id, err, triggers, stored, cb) => {
 };
 
 function assign_active_triggers(stored, triggers) {
-  logger.info('assigning active triggers');
-  logger.info(
-    'iterates over ' +
+  logger.debug('assigning active triggers');
+  logger.debug(
+    'iterates over: ' +
       triggers.map(function (item) {
         return item['id'];
       })
   );
-  logger.info(
-    'compare against stored ' +
+  logger.debug(
+    'compare against stored: ' +
       stored.map(function (item) {
         return item['id'];
       })
@@ -678,7 +678,7 @@ function assign_active_triggers(stored, triggers) {
     });
   });
 
-  logger.info(
+  logger.debug(
     'result: ' +
       intersected_triggers.map(function (item) {
         return item['id'];
@@ -689,7 +689,7 @@ function assign_active_triggers(stored, triggers) {
 }
 
 function delete_all_triggers(id, cb) {
-  logger.info('deleting all triggers');
+  logger.debug('deleting all triggers');
 
   exports.clear_triggers((err) => {
     if (err) {
@@ -701,13 +701,13 @@ function delete_all_triggers(id, cb) {
 function delete_obsolete_triggers(stored, triggers) {
   logger.debug('deleting outdated triggers');
   logger.debug(
-    'iterates over ' +
+    'iterates over: ' +
       triggers.map(function (item) {
         return item['id'];
       })
   );
   logger.debug(
-    'compare against stored ' +
+    'compare against stored: ' +
       stored.map(function (item) {
         return item['id'];
       })
@@ -719,7 +719,7 @@ function delete_obsolete_triggers(stored, triggers) {
     });
   });
 
-  logger.info(
+  logger.debug(
     'result: ' +
       intersected_triggers.map(function (item) {
         return item['id'];
@@ -739,7 +739,7 @@ function handle_triggers_succesfully(success, id, cb, triggers = null) {
       return done(id, error, cb);
     }
 
-    logger.info('triggers fetched from API successfully: ' + success);
+    logger.debug('triggers fetched from API successfully: ' + success);
 
     if (success) {
       exports.sync(id, null, triggers, stored_triggers, () => {
@@ -779,7 +779,7 @@ function refresh_triggers(id, opts, cb) {
 }
 
 exports.clear_triggers = (cb) => {
-  logger.info('cleaning triggers from local db');
+  logger.debug('cleaning triggers from local db');
   storage.do('clear', { type: 'triggers' }, (err) => {
     if (err) logger.error(err.message);
     return cb() && cb(err);

--- a/lib/agent/actions/triggers/index.js
+++ b/lib/agent/actions/triggers/index.js
@@ -8,6 +8,7 @@ var hooks = require('./../../hooks');
 var commands = require('./../../commands');
 var storage = require('./../../utils/storage');
 var lp = require('./../../plugins/control-panel/long-polling');
+const { assign } = require('underscore');
 var emitter;
 var running_triggers = [];
 var event_triggers = {};
@@ -57,6 +58,13 @@ function done(id, err, cb) {
 }
 
 function send_response(status, id_list) {
+  logger.info(
+    'sending ' +
+      status +
+      ' w/ code ' +
+      JSON.stringify(id_list) +
+      " to prey' control panel"
+  );
   var data = {
     status: status,
     command: 'start',
@@ -501,30 +509,26 @@ exports.activate = (trigger) => {
 };
 
 exports.sync = (id, err, triggers, stored, cb) => {
-  if (err) triggers = stored;
   var watching = [];
+
+  if (err) {
+    logger.error('error starting async: ' + err);
+    triggers = stored;
+  }
 
   logger.info('retrieved triggers: ' + JSON.stringify(triggers));
   logger.info('stored triggers: ' + JSON.stringify(stored));
 
   if (triggers.length == 0) {
-    exports.clear_triggers((err) => {
-      if (err) {
-        return done(id, err, cb);
-      }
-    });
+    delete_all_triggers(id, cb); // delete all triggers in local db
+  } else if (stored.length > triggers.length) {
+    stored = delete_obsolete_triggers(stored, triggers); // will remove stored triggers that were deleted in control panel
   }
 
   if (stored.length == 0) {
-    current_triggers = triggers;
+    current_triggers = triggers; // from scratch
   } else {
-    current_triggers = triggers
-      .map((new_trigger) => {
-        if (stored.findIndex((x) => x.id != new_trigger.id) == 0) {
-          return new_trigger;
-        }
-      })
-      .filter((n) => n);
+    current_triggers = assign_active_triggers(stored, triggers); // only active triggers
   }
 
   logger.info('current triggers: ' + JSON.stringify(current_triggers));
@@ -532,10 +536,12 @@ exports.sync = (id, err, triggers, stored, cb) => {
   exports.cancel_all();
   event_triggers = {};
 
+  // stop executing when are no triggers
   if (current_triggers.length == 0) {
     return done(id, null, cb);
   }
 
+  // iterate over only active and filtered triggers
   current_triggers.forEach((trigger, index) => {
     logger.info('checking stored trigger ID: ' + trigger.id);
 
@@ -553,7 +559,7 @@ exports.sync = (id, err, triggers, stored, cb) => {
     }
 
     if (!trigger.synced_at) {
-      trigger.synced_at = new Date().getTime(); // Tiene los 3 digitos extras!!
+      trigger.synced_at = new Date().getTime();
       trigger.last_exec = null;
     }
 
@@ -613,7 +619,7 @@ exports.sync = (id, err, triggers, stored, cb) => {
       var data = {
         id: trigger.id,
         name: trigger.name,
-        persist: trigger.persist, // persist estado inicial? // guardar como 0 o 1
+        persist: trigger.persist, // persist as initial state? // valid values are 0 or 1
         synced_at: trigger.synced_at,
         last_exec: trigger.last_exec,
         automation_events: trigger.automation_events,
@@ -639,11 +645,14 @@ exports.sync = (id, err, triggers, stored, cb) => {
         'set',
         { type: 'triggers', id: trigger.id, data: data },
         (err) => {
-          if (err) logger.error('Error storing triggers: ' + err);
+          if (err) {
+            logger.error('Error storing triggers: ' + err);
+          }
 
           if (index == triggers.length - 1) {
             done(id, null, cb);
           }
+
           finish();
         }
       );
@@ -651,20 +660,46 @@ exports.sync = (id, err, triggers, stored, cb) => {
   });
 
   set_up_hooks();
-
-  // Which reimains in stored array it's added to the action stopped response reason
-  if (stored.length > 0) {
-    var stored_triggers = stored.map((a) => a.id),
-      request_triggers = triggers.map((a) => a.id);
-
-    var deleted = stored_triggers.filter(
-      (el) => !request_triggers.includes(el)
-    );
-    if (deleted.length > 0) {
-      send_response('stopped', deleted);
-    }
-  }
 };
+
+function assign_active_triggers(stored, triggers) {
+  logger.info('assigning active triggers');
+
+  return triggers
+    .map((new_trigger) => {
+      if (stored.findIndex((x) => x.id != new_trigger.id) == 0) {
+        return new_trigger;
+      }
+    })
+    .filter((n) => n);
+}
+function delete_all_triggers(id, cb) {
+  logger.info('deleting all triggers');
+
+  exports.clear_triggers((err) => {
+    if (err) {
+      return done(id, err, cb);
+    }
+  });
+}
+
+function delete_obsolete_triggers(stored, triggers) {
+  logger.info('deleting old triggers');
+
+  stored
+    .map((old_trigger) => {
+      if (triggers.findIndex((x) => x.id != old_trigger.id) == 0) {
+        return old_trigger;
+      }
+    })
+    .filter((n) => n)
+    .forEach((old_trigger, index) => {
+      stored.splice(index, 1);
+      storage.do('del', { type: 'triggers', id: old_trigger.id });
+    });
+
+  return stored;
+}
 
 function handle_triggers_succesfully(success, id, cb, triggers = null) {
   storage.do('all', { type: 'triggers' }, (error, stored_triggers) => {

--- a/lib/agent/actions/triggers/index.js
+++ b/lib/agent/actions/triggers/index.js
@@ -1,22 +1,20 @@
 'use strict';
 
-var schedule = require('node-schedule'),
-  EventEmitter = require('events').EventEmitter,
-  logger = require('./../../common').logger.prefix('triggers'),
-  api = require('./../../plugins/control-panel/api'),
-  hooks = require('./../../hooks'),
-  commands = require('./../../commands'),
-  storage = require('./../../utils/storage'),
-  lp = require('./../../plugins/control-panel/long-polling');
+var schedule = require('node-schedule');
+var EventEmitter = require('events').EventEmitter;
+var logger = require('./../../common').logger.prefix('triggers');
+var api = require('./../../plugins/control-panel/api');
+var hooks = require('./../../hooks');
+var commands = require('./../../commands');
+var storage = require('./../../utils/storage');
+var lp = require('./../../plugins/control-panel/long-polling');
+var emitter;
+var running_triggers = [];
+var event_triggers = {};
+var current_triggers = [];
+var refreshing = false;
 
-var emitter,
-  running_triggers = [],
-  event_triggers = {},
-  refreshing = false;
-
-var da_triggers;
-
-var events_list = [
+const events_list = [
   'connected',
   'disconnected',
   'geofencing_in',
@@ -29,17 +27,17 @@ var events_list = [
   'started_charging',
   'stopped_charging',
   'hardware_changed',
-  'device_unseen'
+  'device_unseen',
 ];
 
-var error_status_list = {
+const error_status_list = {
   0: 'Unknown error',
   1: 'Success!',
   2: 'Invalid trigger format',
   3: 'Cant set trigger into the past!',
   4: "The execution range dates doesn't make sense.",
   5: 'Unavailable event for Node Client.',
-  6: 'Persisting action!'
+  6: 'Persisting action!',
 };
 
 function fetch_triggers(cb) {
@@ -63,7 +61,7 @@ function send_response(status, id_list) {
     status: status,
     command: 'start',
     target: 'triggers',
-    reason: JSON.stringify(id_list)
+    reason: JSON.stringify(id_list),
   };
   api.push['response'](data);
 }
@@ -81,10 +79,18 @@ function check_repeat(date, repeat) {
   try {
     var hour_from = repeat.hour_from,
       hour_until = repeat.hour_until,
-      date_from = date.setHours(hour_from.slice(0, 2), hour_from.slice(2, 4), hour_from.slice(4, 6)),
-      date_until = date.setHours(hour_until.slice(0, 2), hour_until.slice(2, 4), hour_until.slice(4, 6));
+      date_from = date.setHours(
+        hour_from.slice(0, 2),
+        hour_from.slice(2, 4),
+        hour_from.slice(4, 6)
+      ),
+      date_until = date.setHours(
+        hour_until.slice(0, 2),
+        hour_until.slice(2, 4),
+        hour_until.slice(4, 6)
+      );
 
-    limit = {from: date_from, until: date_until};
+    limit = { from: date_from, until: date_until };
   } catch (e) {
     limit = {};
   }
@@ -113,11 +119,20 @@ function check_rules(rule) {
 
 function run_trigger_actions(trigger) {
   // Update last_exec
-  storage.do('update', {type: 'triggers', id: trigger.id, columns: 'last_exec', values: new Date().getTime()}, () => {
-    send_response('stopped', [trigger.id]);
-    storage.do('del', {type: 'triggers', id: trigger.id});
-    return;
-  });
+  storage.do(
+    'update',
+    {
+      type: 'triggers',
+      id: trigger.id,
+      columns: 'last_exec',
+      values: new Date().getTime(),
+    },
+    () => {
+      send_response('stopped', [trigger.id]);
+      storage.do('del', { type: 'triggers', id: trigger.id });
+      return;
+    }
+  );
 
   trigger.automation_actions.forEach((action) => {
     run_action(trigger, action);
@@ -157,11 +172,14 @@ function to_unix(date) {
         second = parseInt(date.slice(12, 14)),
         timezone_offset = new Date().getTimezoneOffset() * 60 * 1000; // miliseconds
 
-      new_date = new Date(Date.UTC(year, month, day, hour, minute, second)).getTime() + timezone_offset;
+      new_date =
+        new Date(Date.UTC(year, month, day, hour, minute, second)).getTime() +
+        timezone_offset;
     } else {
       date = date.split('Z');
       if (date.length > 1) {
-        if (date[1].length > 0) date = date[1].charAt(0) == '-' ? date.join('') : date.join('+');
+        if (date[1].length > 0)
+          date = date[1].charAt(0) == '-' ? date.join('') : date.join('+');
         else date = date[0];
       }
       new_date = new Date(date).getTime();
@@ -190,7 +208,12 @@ function set_up_hooks() {
           var aux_date = new Date(date.valueOf());
           var dates = check_repeat(aux_date, action.repeat);
 
-          if (Object.keys(dates).length == 0 || date.getTime() < dates.from || date.getTime() > dates.until) return;
+          if (
+            Object.keys(dates).length == 0 ||
+            date.getTime() < dates.from ||
+            date.getTime() > dates.until
+          )
+            return;
         }
 
         if (action.after) {
@@ -200,31 +223,49 @@ function set_up_hooks() {
             return;
           }
 
-          if (last_connection + action.after > Math.round(Date.now() / 1000)) return;
+          if (last_connection + action.after > Math.round(Date.now() / 1000))
+            return;
 
           // Don't do if it was already executed
-          var trigger_index = da_triggers.findIndex((obj) => obj.id === action.trigger_id);
-          if (da_triggers[trigger_index].last_exec) return;
+          var trigger_index = current_triggers.findIndex(
+            (obj) => obj.id === action.trigger_id
+          );
+          if (current_triggers[trigger_index].last_exec) return;
 
           var exec_time = new Date().getTime();
-          da_triggers[trigger_index].last_exec = exec_time;
+          current_triggers[trigger_index].last_exec = exec_time;
 
-          var current = da_triggers[trigger_index];
-          storage.do('update', {type: 'triggers', id: current.id, columns: 'synced_at', values: exec_time}, (err) => {
-            if (err) logger.info('Unable to update the execution time');
-          });
+          var current = current_triggers[trigger_index];
+          storage.do(
+            'update',
+            {
+              type: 'triggers',
+              id: current.id,
+              columns: 'synced_at',
+              values: exec_time,
+            },
+            (err) => {
+              if (err) logger.info('Unable to update the execution time');
+            }
+          );
         }
 
         if (action.range) {
           var date_from = action.range.from,
             date_until = action.range.until;
 
-          if (isNaN(date_from) || isNaN(date_until) || date.getTime() < date_from || date.getTime() > date_until)
+          if (
+            isNaN(date_from) ||
+            isNaN(date_until) ||
+            date.getTime() < date_from ||
+            date.getTime() > date_until
+          )
             return;
         }
 
         setTimeout(() => {
-          if (action.action.options) action.action.options.trigger_id = action.trigger_id;
+          if (action.action.options)
+            action.action.options.trigger_id = action.trigger_id;
           commands.perform(action.action);
         }, timeout);
       });
@@ -234,7 +275,9 @@ function set_up_hooks() {
 
 exports.activate_event = (trigger) => {
   try {
-    var event_index = trigger.automation_events.findIndex((obj) => events_list.indexOf(obj.type) > -1);
+    var event_index = trigger.automation_events.findIndex(
+      (obj) => events_list.indexOf(obj.type) > -1
+    );
   } catch (e) {
     return 2;
   }
@@ -250,9 +293,15 @@ exports.activate_event = (trigger) => {
 
   trigger.automation_actions.forEach((action) => {
     // If there's an element with type 'repeat_range_time' we keep the index
-    var index_repeat = trigger.automation_events.findIndex((obj) => obj.type === 'repeat_range_time'),
-      index_range = trigger.automation_events.findIndex((obj) => obj.type === 'range_time'),
-      index_after = trigger.automation_events.findIndex((obj) => obj.type === 'after_time');
+    var index_repeat = trigger.automation_events.findIndex(
+        (obj) => obj.type === 'repeat_range_time'
+      ),
+      index_range = trigger.automation_events.findIndex(
+        (obj) => obj.type === 'range_time'
+      ),
+      index_after = trigger.automation_events.findIndex(
+        (obj) => obj.type === 'after_time'
+      );
 
     if (index_after > -1) {
       var seconds = trigger.automation_events[index_after].info.seconds;
@@ -260,9 +309,13 @@ exports.activate_event = (trigger) => {
     }
 
     if (index_repeat > -1) {
-      var days = JSON.parse(trigger.automation_events[index_repeat].info.days_of_week),
+      var days = JSON.parse(
+          trigger.automation_events[index_repeat].info.days_of_week
+        ),
         hour_from = trigger.automation_events[index_repeat].info.hour_from,
-        hour_until = trigger.automation_events[index_repeat].info.hour_until.slice(0, -2) + '59', // Include that last minute
+        hour_until =
+          trigger.automation_events[index_repeat].info.hour_until.slice(0, -2) +
+          '59', // Include that last minute
         until = trigger.automation_events[index_repeat].info.until;
 
       if (until) {
@@ -278,16 +331,25 @@ exports.activate_event = (trigger) => {
 
       if (!check_repeat_format(days, hour_from, hour_until, until)) return 4;
 
-      action.repeat = {days_of_week: days, hour_from: hour_from, hour_until: hour_until, until: until};
+      action.repeat = {
+        days_of_week: days,
+        hour_from: hour_from,
+        hour_until: hour_until,
+        until: until,
+      };
     }
 
     if (index_range > -1) {
-      var date_from = to_unix(trigger.automation_events[index_range].info.from + '000000'),
-        date_until = to_unix(trigger.automation_events[index_range].info.until + '235959');
+      var date_from = to_unix(
+          trigger.automation_events[index_range].info.from + '000000'
+        ),
+        date_until = to_unix(
+          trigger.automation_events[index_range].info.until + '235959'
+        );
 
       if (current_date > date_until) return 2;
       if (!check_range_format(date_from, date_until)) return 4;
-      action.range = {from: date_from, until: date_until};
+      action.range = { from: date_from, until: date_until };
     }
 
     action.trigger_id = trigger.id;
@@ -303,7 +365,9 @@ exports.activate_event = (trigger) => {
  */
 exports.activate = (trigger) => {
   try {
-    var index = trigger.automation_events.findIndex((obj) => obj.type === 'exact_time' || obj.type === 'repeat_time'),
+    var index = trigger.automation_events.findIndex(
+        (obj) => obj.type === 'exact_time' || obj.type === 'repeat_time'
+      ),
       info = trigger.automation_events[index].info,
       opts;
   } catch (e) {
@@ -319,7 +383,10 @@ exports.activate = (trigger) => {
     var current_date = new Date().getTime();
 
     if (current_date > opts) {
-      if ((trigger.persist == true || trigger.persist == 1) && !trigger.last_exec) {
+      if (
+        (trigger.persist == true || trigger.persist == 1) &&
+        !trigger.last_exec
+      ) {
         run_trigger_actions(trigger);
         return 6;
       } else {
@@ -340,7 +407,7 @@ exports.activate = (trigger) => {
 
       if (!check_rules(rule)) return 2;
 
-      opts = {rule: rule};
+      opts = { rule: rule };
 
       if (info.until) {
         var until_date = info.until,
@@ -360,8 +427,12 @@ exports.activate = (trigger) => {
   } else return 2;
 
   try {
-    var index_repeat = trigger.automation_events.findIndex((obj) => obj.type === 'repeat_range_time'),
-      index_range = trigger.automation_events.findIndex((obj) => obj.type === 'range_time');
+    var index_repeat = trigger.automation_events.findIndex(
+        (obj) => obj.type === 'repeat_range_time'
+      ),
+      index_range = trigger.automation_events.findIndex(
+        (obj) => obj.type === 'range_time'
+      );
   } catch (e) {
     return 2;
   }
@@ -374,7 +445,12 @@ exports.activate = (trigger) => {
       (until = repeat_params.info.until);
 
     if (!check_repeat_format(days, hour_from, hour_until, until)) return 4;
-    var repeat = {days_of_week: days, hour_from: hour_from, hour_until: hour_until, until: until};
+    var repeat = {
+      days_of_week: days,
+      hour_from: hour_from,
+      hour_until: hour_until,
+      until: until,
+    };
   }
 
   if (index_range > -1) {
@@ -383,7 +459,7 @@ exports.activate = (trigger) => {
       date_until = to_unix(range_params.until);
 
     if (!check_range_format(date_from, date_until)) return 4;
-    var range = {from: date_from, until: date_until};
+    var range = { from: date_from, until: date_until };
   }
 
   var da_trigger = schedule.scheduleJob(opts, () => {
@@ -394,13 +470,24 @@ exports.activate = (trigger) => {
 
       var aux_date = new Date(date.valueOf());
       var dates = check_repeat(aux_date, repeat);
-      if (Object.keys(dates).length == 0 || date.getTime() < dates.from || date.getTime() > dates.until) return;
+      if (
+        Object.keys(dates).length == 0 ||
+        date.getTime() < dates.from ||
+        date.getTime() > dates.until
+      )
+        return;
     }
 
     if (range) {
       (date_from = range.from), (date_until = range.until);
 
-      if (isNaN(date_from) || isNaN(date_until) || date.getTime() < date_from || date.getTime() > date_until) return;
+      if (
+        isNaN(date_from) ||
+        isNaN(date_until) ||
+        date.getTime() < date_from ||
+        date.getTime() > date_until
+      )
+        return;
     }
 
     run_trigger_actions(trigger);
@@ -417,7 +504,41 @@ exports.sync = (id, err, triggers, stored, cb) => {
   if (err) triggers = stored;
   var watching = [];
 
-  triggers.forEach((trigger) => {
+  logger.info('retrieved triggers: ' + JSON.stringify(triggers));
+  logger.info('stored triggers: ' + JSON.stringify(stored));
+
+  if (triggers.length == 0) {
+    exports.clear_triggers((err) => {
+      if (err) {
+        return done(id, err, cb);
+      }
+    });
+  }
+
+  if (stored.length == 0) {
+    current_triggers = triggers;
+  } else {
+    current_triggers = triggers
+      .map((new_trigger) => {
+        if (stored.findIndex((x) => x.id != new_trigger.id) == 0) {
+          return new_trigger;
+        }
+      })
+      .filter((n) => n);
+  }
+
+  logger.info('current triggers: ' + JSON.stringify(current_triggers));
+
+  exports.cancel_all();
+  event_triggers = {};
+
+  if (current_triggers.length == 0) {
+    return done(id, null, cb);
+  }
+
+  current_triggers.forEach((trigger, index) => {
+    logger.info('checking stored trigger ID: ' + trigger.id);
+
     if (typeof trigger.automations_events == 'string') {
       try {
         trigger.automations_events = JSON.parse(trigger.automations_events);
@@ -427,29 +548,7 @@ exports.sync = (id, err, triggers, stored, cb) => {
       }
     }
 
-    // The previous states are reassignated
-    var t_id = stored.findIndex((obj) => obj.id === trigger.id);
-
-    if (t_id > -1) {
-      trigger.persist = stored[t_id].persist;
-      trigger.synced_at = stored[t_id].synced_at;
-      trigger.last_exec = stored[t_id].last_exec;
-
-      var stored_index = stored.findIndex((x) => x.id === trigger.id);
-
-      if (stored_index > -1) stored.splice(stored_index, 1);
-    }
-  });
-
-  exports.cancel_all();
-  event_triggers = {};
-  da_triggers = triggers;
-
-  if (triggers.length == 0) return done(id, null, cb);
-
-  triggers.forEach((trigger, index) => {
     if (trigger.options && trigger.options.persist == true) {
-      // ta bien
       trigger.persist = 1;
     }
 
@@ -461,7 +560,11 @@ exports.sync = (id, err, triggers, stored, cb) => {
     var state;
 
     try {
-      if (trigger.automation_events.some((obj) => obj.type === 'exact_time' || obj.type === 'repeat_time')) {
+      if (
+        trigger.automation_events.some(
+          (obj) => obj.type === 'exact_time' || obj.type === 'repeat_time'
+        )
+      ) {
         state = exports.activate(trigger);
       } else state = exports.activate_event(trigger);
     } catch (e) {
@@ -476,12 +579,21 @@ exports.sync = (id, err, triggers, stored, cb) => {
 
     var stored_index = stored.findIndex((x) => x.id === trigger.id);
     if (stored_index == -1 || state != 1) {
-      watching.push({id: trigger.id, state: state});
+      watching.push({ id: trigger.id, state: state });
     }
 
     if (state != 1 && state != 6) {
-      logger.warn('Unable to set up trigger "' + trigger.name + '": ' + error_status_list[state]);
-      if (trigger.persist == false || trigger.persist == null || trigger.persist == 0) {
+      logger.warn(
+        'Unable to set up trigger "' +
+          trigger.name +
+          '": ' +
+          error_status_list[state]
+      );
+      if (
+        trigger.persist == false ||
+        trigger.persist == null ||
+        trigger.persist == 0
+      ) {
         send_response('stopped', [trigger.id]);
       }
 
@@ -490,8 +602,13 @@ exports.sync = (id, err, triggers, stored, cb) => {
       }
       finish();
     } else {
-      if (state == 6) logger.warn('Persisting action for ' + trigger.name);
-      if (!trigger.persist) trigger.persist = 0;
+      if (state == 6) {
+        logger.warn('Persisting action for ' + trigger.name);
+      }
+
+      if (!trigger.persist) {
+        trigger.persist = 0;
+      }
 
       var data = {
         id: trigger.id,
@@ -500,22 +617,39 @@ exports.sync = (id, err, triggers, stored, cb) => {
         synced_at: trigger.synced_at,
         last_exec: trigger.last_exec,
         automation_events: trigger.automation_events,
-        automation_actions: trigger.automation_actions
+        automation_actions: trigger.automation_actions,
       };
 
-      if (!trigger.persist || trigger.persist == false || trigger.persist == 0) data.persist = 0;
-      if (trigger.persist && (trigger.persist == true || trigger.persist == 1)) data.persist = 1;
+      if (
+        !trigger.persist ||
+        trigger.persist == false ||
+        trigger.persist == 0
+      ) {
+        data.persist = 0;
+      }
 
-      storage.do('set', {type: 'triggers', id: trigger.id, data: data}, (err) => {
-        if (err) logger.error('Error storing triggers: ' + err);
+      if (
+        trigger.persist &&
+        (trigger.persist == true || trigger.persist == 1)
+      ) {
+        data.persist = 1;
+      }
 
-        if (index == triggers.length - 1) {
-          done(id, null, cb);
+      storage.do(
+        'set',
+        { type: 'triggers', id: trigger.id, data: data },
+        (err) => {
+          if (err) logger.error('Error storing triggers: ' + err);
+
+          if (index == triggers.length - 1) {
+            done(id, null, cb);
+          }
+          finish();
         }
-        finish();
-      });
+      );
     }
   });
+
   set_up_hooks();
 
   // Which reimains in stored array it's added to the action stopped response reason
@@ -523,52 +657,63 @@ exports.sync = (id, err, triggers, stored, cb) => {
     var stored_triggers = stored.map((a) => a.id),
       request_triggers = triggers.map((a) => a.id);
 
-    var deleted = stored_triggers.filter((el) => !request_triggers.includes(el));
+    var deleted = stored_triggers.filter(
+      (el) => !request_triggers.includes(el)
+    );
     if (deleted.length > 0) {
       send_response('stopped', deleted);
     }
   }
 };
 
-function refresh_triggers(id, opts, cb) {
-  if (refreshing) return;
+function handle_triggers_succesfully(success, id, cb, triggers = null) {
+  storage.do('all', { type: 'triggers' }, (error, stored_triggers) => {
+    if (error || !stored_triggers) {
+      return done(id, error, cb);
+    }
 
-  refreshing = true;
-  emitter = emitter || new EventEmitter();
+    logger.info('triggers fetched from API successfully: ' + success);
 
-  fetch_triggers((err, res) => {
-    if (err) {
-      storage.do('all', {type: 'triggers'}, (err, stored_triggers) => {
-        if (err || !stored_triggers) return done(id, err, cb);
-        exports.clear_triggers((err) => {
-          exports.sync(id, err, [], stored_triggers, () => {
-            cb && cb(null, emitter);
-          });
-        });
+    if (success) {
+      exports.sync(id, null, triggers, stored_triggers, () => {
+        cb && cb(null, emitter);
       });
     } else {
-      var triggers = res.body;
-
-      if (!(triggers instanceof Array)) {
-        var err = new Error('Triggers list is not an array');
-        return done(id, err, cb);
-      }
-
-      storage.do('all', {type: 'triggers'}, (error, stored_triggers) => {
-        if (error || !stored_triggers) return done(id, error, cb);
-        exports.clear_triggers((_error) => {
-          if (_error) return done(id, _error, cb);
-          exports.sync(id, null, triggers, stored_triggers, () => {
-            cb && cb(null, emitter);
-          });
+      exports.clear_triggers((err) => {
+        exports.sync(id, err, [], stored_triggers, () => {
+          cb && cb(null, emitter);
         });
       });
     }
   });
 }
 
+function refresh_triggers(id, opts, cb) {
+  if (refreshing) {
+    return;
+  }
+
+  refreshing = true;
+  emitter = emitter || new EventEmitter();
+
+  fetch_triggers((err, res) => {
+    if (err) {
+      handle_triggers_succesfully(false, id, cb);
+    } else {
+      var fetched_triggers = res.body;
+
+      if (!(fetched_triggers instanceof Array)) {
+        return done(id, new Error('Triggers list is not an array'), cb);
+      }
+
+      handle_triggers_succesfully(true, id, cb, fetched_triggers);
+    }
+  });
+}
+
 exports.clear_triggers = (cb) => {
-  storage.do('clear', {type: 'triggers'}, (err) => {
+  logger.info('cleaning triggers from local db');
+  storage.do('clear', { type: 'triggers' }, (err) => {
     if (err) logger.error(err.message);
     return cb() && cb(err);
   });

--- a/lib/agent/actions/triggers/index.js
+++ b/lib/agent/actions/triggers/index.js
@@ -64,6 +64,7 @@ function send_response(status, id_list) {
       JSON.stringify(id_list) +
       " to prey' control panel"
   );
+
   var data = {
     status: status,
     command: 'start',
@@ -515,20 +516,15 @@ exports.sync = (id, err, triggers, stored, cb) => {
     triggers = stored;
   }
 
-  logger.info('retrieved triggers: ' + JSON.stringify(triggers));
-  logger.info('stored triggers: ' + JSON.stringify(stored));
+  // logger.debug('retrieved triggers: ' + JSON.stringify(triggers));
+  // logger.info('stored triggers: ' + JSON.stringify(stored));
 
   if (triggers.length == 0) {
     delete_all_triggers(id, cb); // delete all triggers in local db
-  } else if (stored.length > triggers.length) {
-    stored = delete_obsolete_triggers(stored, triggers); // will remove stored triggers that were deleted in control panel
   }
 
-  if (stored.length == 0) {
-    current_triggers = triggers; // from scratch
-  } else {
-    current_triggers = assign_active_triggers(stored, triggers); // only active triggers
-  }
+  current_triggers = assign_active_triggers(stored, triggers); // only active triggers
+  stored = delete_obsolete_triggers(stored, triggers); // will remove stored triggers that were deleted in control panel
 
   logger.info('current triggers: ' + JSON.stringify(current_triggers));
 
@@ -542,134 +538,120 @@ exports.sync = (id, err, triggers, stored, cb) => {
 
   // iterate over only active and filtered triggers
   current_triggers.forEach((trigger, index) => {
-    
-    // prevent error trying to insert a existing record
-    storage.do(
-      'query',
-      { type: 'triggers', column: 'id', data: String(trigger.id) },
-      (_err, triggers) => {
-        if (triggers && triggers.length == 0) {
-          logger.info('checking stored trigger ID: ' + trigger.id);
+    logger.info('saving stored trigger ID: ' + trigger.id);
 
-          if (typeof trigger.automations_events == 'string') {
-            try {
-              trigger.automations_events = JSON.parse(
-                trigger.automations_events
-              );
-              trigger.automations_actions = JSON.parse(
-                trigger.automations_action
-              );
-            } catch (e) {
-              logger.warn('Error parsing trigger options: ' + e.message);
-            }
-          }
-
-          if (trigger.options && trigger.options.persist == true) {
-            trigger.persist = 1;
-          }
-
-          if (!trigger.synced_at) {
-            trigger.synced_at = new Date().getTime();
-            trigger.last_exec = null;
-          }
-
-          var state;
-
-          try {
-            if (
-              trigger.automation_events.some(
-                (obj) => obj.type === 'exact_time' || obj.type === 'repeat_time'
-              )
-            ) {
-              state = exports.activate(trigger);
-            } else state = exports.activate_event(trigger);
-          } catch (e) {
-            state = 0;
-          }
-
-          var finish = () => {
-            if (index == triggers.length - 1 && watching.length > 0) {
-              send_response('started', watching);
-            }
-          };
-
-          var stored_index = stored.findIndex((x) => x.id === trigger.id);
-          if (stored_index == -1 || state != 1) {
-            watching.push({ id: trigger.id, state: state });
-          }
-
-          if (state != 1 && state != 6) {
-            logger.warn(
-              'Unable to set up trigger "' +
-                trigger.name +
-                '": ' +
-                error_status_list[state]
-            );
-            if (
-              trigger.persist == false ||
-              trigger.persist == null ||
-              trigger.persist == 0
-            ) {
-              send_response('stopped', [trigger.id]);
-            }
-
-            if (index == triggers.length - 1) {
-              done(id, null, cb);
-            }
-            finish();
-          } else {
-            if (state == 6) {
-              logger.warn('Persisting action for ' + trigger.name);
-            }
-
-            if (!trigger.persist) {
-              trigger.persist = 0;
-            }
-
-            var data = {
-              id: trigger.id,
-              name: trigger.name,
-              persist: trigger.persist, // persist as initial state? // valid values are 0 or 1
-              synced_at: trigger.synced_at,
-              last_exec: trigger.last_exec,
-              automation_events: trigger.automation_events,
-              automation_actions: trigger.automation_actions,
-            };
-
-            if (
-              !trigger.persist ||
-              trigger.persist == false ||
-              trigger.persist == 0
-            ) {
-              data.persist = 0;
-            }
-
-            if (
-              trigger.persist &&
-              (trigger.persist == true || trigger.persist == 1)
-            ) {
-              data.persist = 1;
-            }
-
-            storage.do(
-              'set',
-              { type: 'triggers', id: trigger.id, data: data },
-              (err) => {
-                if (err) {
-                  logger.error('Error storing triggers: ' + err);
-                }
-
-                if (index == triggers.length - 1) {
-                  done(id, null, cb);
-                }
-
-                finish();
-              }
-            );
-          }
-        }
+    if (typeof trigger.automations_events == 'string') {
+      try {
+        trigger.automations_events = JSON.parse(trigger.automations_events);
+        trigger.automations_actions = JSON.parse(trigger.automations_action);
+      } catch (e) {
+        logger.warn('Error parsing trigger options: ' + e.message);
       }
-    );
+    }
+
+    if (trigger.options && trigger.options.persist == true) {
+      trigger.persist = 1;
+    }
+
+    if (!trigger.synced_at) {
+      trigger.synced_at = new Date().getTime();
+      trigger.last_exec = null;
+    }
+
+    var state;
+
+    try {
+      if (
+        trigger.automation_events.some(
+          (obj) => obj.type === 'exact_time' || obj.type === 'repeat_time'
+        )
+      ) {
+        state = exports.activate(trigger);
+      } else state = exports.activate_event(trigger);
+    } catch (e) {
+      state = 0;
+    }
+
+    var finish = () => {
+      if (index == triggers.length - 1 && watching.length > 0) {
+        send_response('started', watching);
+      }
+    };
+
+    var stored_index = stored.findIndex((x) => x.id === trigger.id);
+    if (stored_index == -1 || state != 1) {
+      watching.push({ id: trigger.id, state: state });
+    }
+
+    if (state != 1 && state != 6) {
+      logger.warn(
+        'Unable to set up trigger "' +
+          trigger.name +
+          '": ' +
+          error_status_list[state]
+      );
+      if (
+        trigger.persist == false ||
+        trigger.persist == null ||
+        trigger.persist == 0
+      ) {
+        send_response('stopped', [trigger.id]);
+      }
+
+      if (index == triggers.length - 1) {
+        done(id, null, cb);
+      }
+      finish();
+    } else {
+      if (state == 6) {
+        logger.warn('Persisting action for ' + trigger.name);
+      }
+
+      if (!trigger.persist) {
+        trigger.persist = 0;
+      }
+
+      var data = {
+        id: trigger.id,
+        name: trigger.name,
+        persist: trigger.persist, // persist as initial state? // valid values are 0 or 1
+        synced_at: trigger.synced_at,
+        last_exec: trigger.last_exec,
+        automation_events: trigger.automation_events,
+        automation_actions: trigger.automation_actions,
+      };
+
+      if (
+        !trigger.persist ||
+        trigger.persist == false ||
+        trigger.persist == 0
+      ) {
+        data.persist = 0;
+      }
+
+      if (
+        trigger.persist &&
+        (trigger.persist == true || trigger.persist == 1)
+      ) {
+        data.persist = 1;
+      }
+
+      storage.do(
+        'set',
+        { type: 'triggers', id: trigger.id, data: data },
+        (err) => {
+          if (err) {
+            logger.error('Error storing triggers: ' + err);
+          }
+
+          if (index == triggers.length - 1) {
+            done(id, null, cb);
+          }
+
+          finish();
+        }
+      );
+    }
   });
 
   set_up_hooks();
@@ -677,15 +659,35 @@ exports.sync = (id, err, triggers, stored, cb) => {
 
 function assign_active_triggers(stored, triggers) {
   logger.info('assigning active triggers');
+  logger.info(
+    'iterates over ' +
+      triggers.map(function (item) {
+        return item['id'];
+      })
+  );
+  logger.info(
+    'compare against stored ' +
+      stored.map(function (item) {
+        return item['id'];
+      })
+  );
 
-  return triggers
-    .map((new_trigger) => {
-      if (stored.findIndex((x) => x.id != new_trigger.id) == 0) {
-        return new_trigger;
-      }
-    })
-    .filter((n) => n);
+  const intersected_triggers = triggers.filter((new_trigger) => {
+    return !stored.some((old_trigger) => {
+      return old_trigger.id.toString() === new_trigger.id.toString();
+    });
+  });
+
+  logger.info(
+    'result: ' +
+      intersected_triggers.map(function (item) {
+        return item['id'];
+      })
+  );
+
+  return intersected_triggers;
 }
+
 function delete_all_triggers(id, cb) {
   logger.info('deleting all triggers');
 
@@ -697,21 +699,38 @@ function delete_all_triggers(id, cb) {
 }
 
 function delete_obsolete_triggers(stored, triggers) {
-  logger.info('deleting old triggers');
+  logger.debug('deleting outdated triggers');
+  logger.debug(
+    'iterates over ' +
+      triggers.map(function (item) {
+        return item['id'];
+      })
+  );
+  logger.debug(
+    'compare against stored ' +
+      stored.map(function (item) {
+        return item['id'];
+      })
+  );
 
-  stored
-    .map((old_trigger) => {
-      if (triggers.findIndex((x) => x.id != old_trigger.id) == 0) {
-        return old_trigger;
-      }
-    })
-    .filter((n) => n)
-    .forEach((old_trigger, index) => {
-      stored.splice(index, 1);
-      storage.do('del', { type: 'triggers', id: old_trigger.id });
+  const intersected_triggers = stored.filter((old_trigger) => {
+    return !triggers.some((new_trigger) => {
+      return old_trigger.id.toString() === new_trigger.id.toString();
     });
+  });
 
-  return stored;
+  logger.info(
+    'result: ' +
+      intersected_triggers.map(function (item) {
+        return item['id'];
+      })
+  );
+
+  intersected_triggers.forEach((o) =>
+    storage.do('del', { type: 'triggers', id: o.id })
+  );
+
+  return intersected_triggers;
 }
 
 function handle_triggers_succesfully(success, id, cb, triggers = null) {

--- a/lib/agent/actions/triggers/index.js
+++ b/lib/agent/actions/triggers/index.js
@@ -8,7 +8,6 @@ var hooks = require('./../../hooks');
 var commands = require('./../../commands');
 var storage = require('./../../utils/storage');
 var lp = require('./../../plugins/control-panel/long-polling');
-const { assign } = require('underscore');
 var emitter;
 var running_triggers = [];
 var event_triggers = {};
@@ -543,120 +542,134 @@ exports.sync = (id, err, triggers, stored, cb) => {
 
   // iterate over only active and filtered triggers
   current_triggers.forEach((trigger, index) => {
-    logger.info('checking stored trigger ID: ' + trigger.id);
+    
+    // prevent error trying to insert a existing record
+    storage.do(
+      'query',
+      { type: 'triggers', column: 'id', data: String(trigger.id) },
+      (_err, triggers) => {
+        if (triggers && triggers.length == 0) {
+          logger.info('checking stored trigger ID: ' + trigger.id);
 
-    if (typeof trigger.automations_events == 'string') {
-      try {
-        trigger.automations_events = JSON.parse(trigger.automations_events);
-        trigger.automations_actions = JSON.parse(trigger.automations_action);
-      } catch (e) {
-        logger.warn('Error parsing trigger options: ' + e.message);
-      }
-    }
-
-    if (trigger.options && trigger.options.persist == true) {
-      trigger.persist = 1;
-    }
-
-    if (!trigger.synced_at) {
-      trigger.synced_at = new Date().getTime();
-      trigger.last_exec = null;
-    }
-
-    var state;
-
-    try {
-      if (
-        trigger.automation_events.some(
-          (obj) => obj.type === 'exact_time' || obj.type === 'repeat_time'
-        )
-      ) {
-        state = exports.activate(trigger);
-      } else state = exports.activate_event(trigger);
-    } catch (e) {
-      state = 0;
-    }
-
-    var finish = () => {
-      if (index == triggers.length - 1 && watching.length > 0) {
-        send_response('started', watching);
-      }
-    };
-
-    var stored_index = stored.findIndex((x) => x.id === trigger.id);
-    if (stored_index == -1 || state != 1) {
-      watching.push({ id: trigger.id, state: state });
-    }
-
-    if (state != 1 && state != 6) {
-      logger.warn(
-        'Unable to set up trigger "' +
-          trigger.name +
-          '": ' +
-          error_status_list[state]
-      );
-      if (
-        trigger.persist == false ||
-        trigger.persist == null ||
-        trigger.persist == 0
-      ) {
-        send_response('stopped', [trigger.id]);
-      }
-
-      if (index == triggers.length - 1) {
-        done(id, null, cb);
-      }
-      finish();
-    } else {
-      if (state == 6) {
-        logger.warn('Persisting action for ' + trigger.name);
-      }
-
-      if (!trigger.persist) {
-        trigger.persist = 0;
-      }
-
-      var data = {
-        id: trigger.id,
-        name: trigger.name,
-        persist: trigger.persist, // persist as initial state? // valid values are 0 or 1
-        synced_at: trigger.synced_at,
-        last_exec: trigger.last_exec,
-        automation_events: trigger.automation_events,
-        automation_actions: trigger.automation_actions,
-      };
-
-      if (
-        !trigger.persist ||
-        trigger.persist == false ||
-        trigger.persist == 0
-      ) {
-        data.persist = 0;
-      }
-
-      if (
-        trigger.persist &&
-        (trigger.persist == true || trigger.persist == 1)
-      ) {
-        data.persist = 1;
-      }
-
-      storage.do(
-        'set',
-        { type: 'triggers', id: trigger.id, data: data },
-        (err) => {
-          if (err) {
-            logger.error('Error storing triggers: ' + err);
+          if (typeof trigger.automations_events == 'string') {
+            try {
+              trigger.automations_events = JSON.parse(
+                trigger.automations_events
+              );
+              trigger.automations_actions = JSON.parse(
+                trigger.automations_action
+              );
+            } catch (e) {
+              logger.warn('Error parsing trigger options: ' + e.message);
+            }
           }
 
-          if (index == triggers.length - 1) {
-            done(id, null, cb);
+          if (trigger.options && trigger.options.persist == true) {
+            trigger.persist = 1;
           }
 
-          finish();
+          if (!trigger.synced_at) {
+            trigger.synced_at = new Date().getTime();
+            trigger.last_exec = null;
+          }
+
+          var state;
+
+          try {
+            if (
+              trigger.automation_events.some(
+                (obj) => obj.type === 'exact_time' || obj.type === 'repeat_time'
+              )
+            ) {
+              state = exports.activate(trigger);
+            } else state = exports.activate_event(trigger);
+          } catch (e) {
+            state = 0;
+          }
+
+          var finish = () => {
+            if (index == triggers.length - 1 && watching.length > 0) {
+              send_response('started', watching);
+            }
+          };
+
+          var stored_index = stored.findIndex((x) => x.id === trigger.id);
+          if (stored_index == -1 || state != 1) {
+            watching.push({ id: trigger.id, state: state });
+          }
+
+          if (state != 1 && state != 6) {
+            logger.warn(
+              'Unable to set up trigger "' +
+                trigger.name +
+                '": ' +
+                error_status_list[state]
+            );
+            if (
+              trigger.persist == false ||
+              trigger.persist == null ||
+              trigger.persist == 0
+            ) {
+              send_response('stopped', [trigger.id]);
+            }
+
+            if (index == triggers.length - 1) {
+              done(id, null, cb);
+            }
+            finish();
+          } else {
+            if (state == 6) {
+              logger.warn('Persisting action for ' + trigger.name);
+            }
+
+            if (!trigger.persist) {
+              trigger.persist = 0;
+            }
+
+            var data = {
+              id: trigger.id,
+              name: trigger.name,
+              persist: trigger.persist, // persist as initial state? // valid values are 0 or 1
+              synced_at: trigger.synced_at,
+              last_exec: trigger.last_exec,
+              automation_events: trigger.automation_events,
+              automation_actions: trigger.automation_actions,
+            };
+
+            if (
+              !trigger.persist ||
+              trigger.persist == false ||
+              trigger.persist == 0
+            ) {
+              data.persist = 0;
+            }
+
+            if (
+              trigger.persist &&
+              (trigger.persist == true || trigger.persist == 1)
+            ) {
+              data.persist = 1;
+            }
+
+            storage.do(
+              'set',
+              { type: 'triggers', id: trigger.id, data: data },
+              (err) => {
+                if (err) {
+                  logger.error('Error storing triggers: ' + err);
+                }
+
+                if (index == triggers.length - 1) {
+                  done(id, null, cb);
+                }
+
+                finish();
+              }
+            );
+          }
         }
-      );
-    }
+      }
+    );
   });
 
   set_up_hooks();

--- a/lib/agent/commands.js
+++ b/lib/agent/commands.js
@@ -1,45 +1,39 @@
-var common    = require('./common'),
-    hooks     = require('./hooks'),
-    actions   = require('./actions'),
-    triggers  = require('./triggers'),
-    providers = require('./providers'),
-    reports   = require('./reports'),
-    updater   = require('./updater'),
-    storage = require('./utils/storage'),
-    devices   = require('./plugins/control-panel/api/devices'),
-    token   = require('./token');
+var common = require('./common');
+var hooks = require('./hooks');
+var actions = require('./actions');
+var triggers = require('./triggers');
+var providers = require('./providers');
+var reports = require('./reports');
+var updater = require('./updater');
+var storage = require('./utils/storage');
+var devices = require('./plugins/control-panel/api/devices');
+var logger = common.logger.prefix('commands');
+var watching = false; // flag for storing new commands when fired
+var id;
 
 const { v4: uuidv4 } = require('uuid');
-
-var logger    = common.logger.prefix('commands');
-var watching  = false; // flag for storing new commands when fired
-
-
 const actions_not_allowed = ['user_activated'];
 ////////////////////////////////////////////////////////////////////
 // helpers
 
 // transforms this 'host:myhost.com user:god'
 // into this: {host: 'myhost.com', user: 'god' }
-var parse_arguments = function(args) {
+var parse_arguments = function (args) {
   if (!args || args.trim() === '') return;
   try {
-    var formatted = args.trim().replace(/([\w\.]+)/g,'"$1"').replace(/" /g, '",');
+    var formatted = args
+      .trim()
+      .replace(/([\w\.]+)/g, '"$1"')
+      .replace(/" /g, '",');
     return JSON.parse('{' + formatted + '}');
-  } catch(e) {
+  } catch (e) {
     console.log('Invalid argument format.');
   }
 };
 
-var get_destination = function(context, destination, args) {
-  var opts = args.trim() === '' ? null : parse_arguments(args);
-  return { endpoint: destination, options: opts };
-};
-
-var handle_error = function(err) {
+var handle_error = function (err) {
   hooks.trigger('error', err);
-}
-
+};
 ////////////////////////////////////////////////////////////////////
 // build/run/parse/perform/process exports
 
@@ -47,116 +41,135 @@ exports.build = function build(command, target, options) {
   var obj = { command: command, target: target };
   if (options) obj.options = options;
   return obj;
-}
+};
 
-exports.run = function(command, target, options) {
+exports.run = function (command, target, options) {
   var obj = exports.build(command, target, options);
   if (obj) exports.perform(obj);
-}
+};
 
-exports.parse = function(body) {
+exports.parse = function (body) {
   var c;
+  var matches;
 
-  if (matches = body.match(/^help\s?(\w+)?/))
-    c = ['help', matches[1]];
+  if ((matches = body.match(/^help\s?(\w+)?/))) c = ['help', matches[1]];
 
   // on [event] [start|stop] [something]
-  if (matches = body.match(/^(on|once) ([\w\-]+) (config|start|stop|get|set|send) (.+)/))
+  if (
+    (matches = body.match(
+      /^(on|once) ([\w\-]+) (config|start|stop|get|set|send) (.+)/
+    ))
+  )
     c = ['hook', matches[1], matches[2], body];
 
-  if (matches = body.match(/^config read ([\w-]+)/))
+  if ((matches = body.match(/^config read ([\w-]+)/)))
     c = ['config', [matches[1]]];
 
-  if (matches = body.match(/^config update (\w+)\s(?:to )?(\w+)/))
-    c = ['command', this.build('update', matches[1], matches[2]) ];
+  if ((matches = body.match(/^config update (\w+)\s(?:to )?(\w+)/)))
+    c = ['command', this.build('update', matches[1], matches[2])];
 
-  if (matches = body.match(/^upgrade/))
+  if ((matches = body.match(/^upgrade/)))
     c = ['command', this.build('upgrade')];
 
-  if (matches = body.match(/^start ([\w\-]+)(?: (using|with) )?(.*)/))
-    c = ['command', this.build('start', matches[1], parse_arguments(matches[3]))];
+  if ((matches = body.match(/^start ([\w\-]+)(?: (using|with) )?(.*)/)))
+    c = [
+      'command',
+      this.build('start', matches[1], parse_arguments(matches[3])),
+    ];
 
-  if (matches = body.match(/^watch ([\w\-]+)(?: (using|with) )?(.*)/))
-    c = ['command', this.build('watch', matches[1], parse_arguments(matches[3]))];
+  if ((matches = body.match(/^watch ([\w\-]+)(?: (using|with) )?(.*)/)))
+    c = [
+      'command',
+      this.build('watch', matches[1], parse_arguments(matches[3])),
+    ];
 
-  if (matches = body.match(/^stop ([\w\-]+)/))
+  if ((matches = body.match(/^stop ([\w\-]+)/)))
     c = ['command', this.build('stop', matches[1])];
 
-  if (matches = body.match(/^unwatch ([\w\-]+)/))
+  if ((matches = body.match(/^unwatch ([\w\-]+)/)))
     c = ['command', this.build('unwatch', matches[1])];
 
-  if (matches = body.match(/^(?:get|send) ([\w\/\.]+)(?: to )?([\w@\.:\/]+)?(?: (using|with) )?(.*)/)) {
-
+  if (
+    (matches = body.match(
+      /^(?:get|send) ([\w\/\.]+)(?: to )?([\w@\.:\/]+)?(?: (using|with) )?(.*)/
+    ))
+  ) {
     // var destination = matches[2] ? [matches[1].trim(), matches[2].trim(), matches[3]] : {};
-
     if (matches[1][0] == '/' && matches[1].match(/\.(...?)/))
       c = ['send_file', [matches[1].trim()]];
-    else if (matches[1])
-      c = ['command', this.build('get', matches[1].trim())];
-
+    else if (matches[1]) c = ['command', this.build('get', matches[1].trim())];
   }
 
   return c;
-}
+};
 
-exports.perform = function(command) {
-  if (!command)
-    return handle_error(new Error('No command received'));
+exports.perform = function (command) {
+  if (!command) return handle_error(new Error('No command received'));
 
   if (typeof command.options == 'string') {
     try {
       command.options = JSON.parse(command.options);
     } catch (e) {
-      logger.warn("Error parsing command options: " + e.message)
+      logger.warn('Error parsing command options: ' + e.message);
     }
   }
 
-  ///////////////////////////////
-  var id;
-  if (command.id)
+  // verify if id comes as part of the message.
+  // if it's not present is created using uuidv4
+  if (command.id) {
     id = command.id;
-  else if (command.options && command.options.messageID)
+  } else if (command.options && command.options.messageID) {
     id = command.options.messageID;
-  else
+  } else {
     id = uuidv4();
+  }
 
-  if (command.body)
+  if (command.body) {
     command = command.body;
+  }
 
-  ///////////////////////////////
-
-  logger.info("Command received: " + JSON.stringify(command));
+  logger.info('Command received: ' + JSON.stringify(command));
 
   var methods = {
-    'start'   : actions.start,
-    'stop'    : actions.stop,
-    'watch'   : triggers.add,
-    'unwatch' : actions.stop,
-    'get'     : providers.get,
-    'report'  : reports.get,
-    'cancel'  : reports.cancel,
-    'upgrade' : updater.check
-  }
+    start: actions.start,
+    stop: actions.stop,
+    watch: triggers.add,
+    unwatch: actions.stop,
+    get: providers.get,
+    report: reports.get,
+    cancel: reports.cancel,
+    upgrade: updater.check,
+  };
 
   // Intercept {command: 'get', target: 'report', options: {interval: 5}}
   // This kind of report should be storable. To ensure it can be stored we need
   // to change it to {command: 'report', target: 'stolen'}
-  if (command.command === "get" && command.target === "report" && command.options.interval) {
+  if (
+    command.command === 'get' &&
+    command.target === 'report' &&
+    command.options.interval
+  ) {
     command.command = 'report';
     command.target = 'stolen';
   }
 
   // Automation command to mark as missing and recovered from here
-  if (command.command === "start" && (command.target === "missing" || command.target === "recover")) {
-    var set_missing = command.target === "missing" ? true : false;
+  if (
+    command.command === 'start' &&
+    (command.target === 'missing' || command.target === 'recover')
+  ) {
+    var set_missing = command.target === 'missing' ? true : false;
 
     // Set as missing or recovered on the control panel
     devices.post_missing(set_missing, (err) => {
-      if (err) logger.warn('Unable to set missing state to the device: ' + err.message);
+      if (err)
+        logger.warn(
+          'Unable to set missing state to the device: ' + err.message
+        );
     });
 
     // Initialize (or end) reports process on the client
-    var is_stolen = reports.running().some(e => e.name == 'stolen');
+    var is_stolen = reports.running().some((e) => e.name == 'stolen');
     if (set_missing && !is_stolen) {
       command.command = 'report';
       command.target = 'stolen';
@@ -166,53 +179,57 @@ exports.perform = function(command) {
     }
   }
 
-  var type    = command.command || command.name,
-      method  = methods[type];
+  var type = command.command || command.name,
+    method = methods[type];
 
-  if (method && !actions_not_allowed.find(x => x == command.target)) {
+  if (method && !actions_not_allowed.find((x) => x == command.target)) {
     hooks.trigger('command', method, command.target, command.options);
 
     if (command.command != 'start') {
-      if (command.command == 'get' || command.command == 'report' || command.command == 'cancel') {
+      if (
+        command.command == 'get' ||
+        command.command == 'report' ||
+        command.command == 'cancel'
+      ) {
         if (command.command == 'cancel' && command.target == 'stolen')
           delete_same_target(id, 'stolen', () => {
-            logger.debug('Deleted report stored command')
+            logger.debug('Deleted report stored command');
           });
         method(command.target, command.options);
       } else {
         method(id, command.target, command.options);
       }
-    }
-    else {
-      verify_if_executed(id, (err, executed) => {  // Was executed and finished
-          if (!executed) {   
-            let target = verify_if_is_full_wipe(command.target,'fullwipe');
-            command.options.target = command.target;
-            command.target = target;
-            method(id, command.target, command.options);
-           
-          } else {
-            logger.warn(`Action with id ${id} was already executed`);
-          }
-        
-      })
+    } else {
+      verify_if_executed(id, (err, executed) => {
+        // Was executed and finished
+        if (!executed) {
+          let target = verify_if_is_full_wipe(command.target, 'fullwipe');
+          command.options.target = command.target;
+          command.target = target;
+          method(id, command.target, command.options);
+        } else {
+          logger.warn(`Action with id ${id} was already executed`);
+        }
+      });
     }
     update_stored(type, id, command.target, command.options);
   } else {
-    handle_error(new Error('Unknown command: ' + (command.command || command.name)))
+    handle_error(
+      new Error('Unknown command: ' + (command.command || command.name))
+    );
   }
-}
+};
 
-exports.process = function(str) {
+exports.process = function (str) {
   try {
     var commands = JSON.parse(str);
     logger.info('Got commands.');
-  } catch(e) {
+  } catch (e) {
     return handle_error(new Error('Invalid commands: ' + str));
   }
 
   commands.forEach(this.perform);
-}
+};
 
 ////////////////////////////////////////////////////////////////////
 // command persistence
@@ -220,110 +237,148 @@ exports.store = store;
 
 // When storing an action it gets deleted only when an action with the same name arrives.
 var delete_same_target = (id, target, cb) => {
-  storage.do('query', {type: 'commands', column: "target", data: target}, (err, actions) => {
-    if (actions && actions.length == 0) return cb();
-    actions.forEach((action, index) => {
-      if (id != action.id) {
-        storage.do('del', {type: 'commands', id: action.id}, () => {
-          if (index == actions.length - 1) return cb();
-        });
-      }
-      else if (index == actions.length - 1) return cb();
-    });
-  });  
-}
+  storage.do(
+    'query',
+    { type: 'commands', column: 'target', data: target },
+    (err, actions) => {
+      if (actions && actions.length == 0) return cb();
+      actions.forEach((action, index) => {
+        if (id != action.id) {
+          storage.do('del', { type: 'commands', id: action.id }, () => {
+            if (index == actions.length - 1) return cb();
+          });
+        } else if (index == actions.length - 1) return cb();
+      });
+    }
+  );
+};
 
-var store = function(type, id, name, opts, cb) {
+var store = function (type, id, name, opts, cb) {
   logger.debug('Storing command in DB: ' + [type, name].join('-'));
 
   delete_same_target(id, name, () => {
-    if (name == 'geofencing' || name == 'triggers' || name == 'fileretrieval') return cb && cb();
-    storage.do('set', {type: 'commands', id: id, data: {command: type, target: name, options: opts }}, cb);
-  })
-}
-
-var remove = function(type, id, name, cb) {
-  logger.debug('Removing command from DB: ' + [type, name].join('-'));
-  storage.do('del', { type: 'commands', id: id }, cb)
-}
-
-var verify_if_executed = function(id, cb) {
-  storage.do('query', {type: 'commands', column: "id", data: id}, function (err,rows) {
-    if (err) return cb(err);
-
-    if (rows && rows.length == 0 || (rows[0] && rows[0].stopped == 'NULL')) return cb(null, false);
-    else return cb(null, true);
+    if (name == 'geofencing' || name == 'triggers' || name == 'fileretrieval')
+      return cb && cb();
+    storage.do(
+      'set',
+      {
+        type: 'commands',
+        id: id,
+        data: { command: type, target: name, options: opts },
+      },
+      cb
+    );
   });
-}
+};
 
-var verify_if_is_full_wipe = function(target,word) {
+var remove = function (type, id, name, cb) {
+  logger.debug('Removing command from DB: ' + [type, name].join('-'));
+  storage.do('del', { type: 'commands', id: id }, cb);
+};
+
+var verify_if_executed = function (id, cb) {
+  storage.do(
+    'query',
+    { type: 'commands', column: 'id', data: id },
+    function (err, rows) {
+      if (err) return cb(err);
+
+      if ((rows && rows.length == 0) || (rows[0] && rows[0].stopped == 'NULL'))
+        return cb(null, false);
+      else return cb(null, true);
+    }
+  );
+};
+
+var verify_if_is_full_wipe = function (target, word) {
   let result = target.split(word);
-  if (result && result.length==2 && result[1] =='windows') 
-    return word;
+  if (result && result.length == 2 && result[1] == 'windows') return word;
   return target;
-}
+};
 
 // record when actions, triggers and reports are started
-var update_stored = function(type, id, name, opts) {
+var update_stored = function (type, id, name, opts) {
   if (!watching) return;
 
   var storable = ['start', 'watch', 'report'];
 
-  if (type == 'cancel') // report cancelled
+  if (type == 'cancel')
+    // report cancelled
     remove('report', id, name);
-   
   else if (storable.indexOf(type) !== -1) {
     store(type, id, name, opts);
   }
-}
+};
 
 // listen for new commands and add them to storage, in case the app crashes
-var watch_stopped = function() {
+var watch_stopped = function () {
   if (!watching) return;
 
-  hooks.on('action', function(event, id) { 
+  hooks.on('action', function (event, id) {
     if (event == 'stopped' || event == 'failed') {
-      storage.do('update', { type: 'commands', id: id, columns: 'stopped', values: new Date().toISOString() }, (err) => {
-        if (err) logger.warn("Unable to update stopped action timestamp for id:" + id)
-      })
+      storage.do(
+        'update',
+        {
+          type: 'commands',
+          id: id,
+          columns: 'stopped',
+          values: new Date().toISOString(),
+        },
+        (err) => {
+          if (err)
+            logger.warn(
+              'Unable to update stopped action timestamp for id:' + id
+            );
+        }
+      );
     }
 
     if (event == 'started') {
-      storage.do('update', { type: 'commands', id: id, columns: 'started', values: new Date().toISOString() }, (err) => {
-        if (err) logger.warn("Unable to update started action timestamp for id:" + id)
-      })
+      storage.do(
+        'update',
+        {
+          type: 'commands',
+          id: id,
+          columns: 'started',
+          values: new Date().toISOString(),
+        },
+        (err) => {
+          if (err)
+            logger.warn(
+              'Unable to update started action timestamp for id:' + id
+            );
+        }
+      );
     }
   });
 
-  hooks.on('trigger', function(event, name) {
-    if (event == 'stopped')
-      remove('watch', name);
+  hooks.on('trigger', function (event, name) {
+    if (event == 'stopped') remove('watch', name);
   });
-}
+};
 
-exports.start_watching = function() {
+exports.start_watching = function () {
   watching = true;
   watch_stopped();
-}
+};
 
-exports.stop_watching = function() {
+exports.stop_watching = function () {
   watching = false;
-}
+};
 
-exports.run_stored = function(cb) {
-  storage.do('all', {type: 'commands'}, (err, commands) => {
-    if (err || !commands) return logger.error(err.message); 
+exports.run_stored = function (cb) {
+  storage.do('all', { type: 'commands' }, (err, commands) => {
+    if (err || !commands) return logger.error(err.message);
 
     var count = Object.keys(commands).length;
-    if (count <= 0)
-      return;
+    if (count <= 0) return;
 
     for (let id in commands) {
       if (commands[id].stopped == 'NULL') {
-        logger.warn('Relaunching ');  // modificar mensaje
+        logger.warn('Relaunching '); // modificar mensaje
         exports.perform(commands[id]);
         continue;
       }
     }
-  })
-}
+  });
+};

--- a/lib/agent/common.js
+++ b/lib/agent/common.js
@@ -1,22 +1,24 @@
-var join        = require('path').join,
-    common      = require(join(__dirname, '..', 'common')),
-    program     = common.program,
-    paths       = common.system.paths;
+var join = require('path').join,
+  common = require(join(__dirname, '..', 'common')),
+  program = common.program,
+  paths = common.system.paths;
 
-common.helpers  = require('./helpers');
+common.helpers = require('./helpers');
 
-var log_file    = (program.logfile || common.helpers.running_on_background())
-                ? (program.logfile || paths.log_file) : null;
+var log_file =
+  program.logfile || common.helpers.running_on_background()
+    ? program.logfile || paths.log_file
+    : null;
 
-var log_level   = program.debug ? 'debug' : 'info';
-common.logger   = require('petit').new({
-                    level   : log_level,
-                    file    : log_file,
-                    rotate  : true,
-                    size    : 2000000,
-                    limit   : 9,
-                    compress: true,
-                    dest    : paths.config
-                  });
+var log_level = process.env.DEBUG ? 'debug' : 'info';
+common.logger = require('petit').new({
+  level: log_level,
+  file: log_file,
+  rotate: true,
+  size: 2000000,
+  limit: 9,
+  compress: true,
+  dest: paths.config,
+});
 
-module.exports  = common;
+module.exports = common;

--- a/lib/agent/hooks.js
+++ b/lib/agent/hooks.js
@@ -1,29 +1,28 @@
-var logger  = require('./common').logger.prefix('hooks'),
-    Emitter = require('events').EventEmitter,
-    emitter = new Emitter();
+var logger = require('./common').logger.prefix('hooks');
+var Emitter = require('events').EventEmitter;
+var emitter = new Emitter();
 
-var trigger = function(event) {
+var trigger = function (event) {
   logger.info('Hook triggered: ' + event, arguments[1]);
   emitter.emit.apply(this, arguments);
-}
+};
 
-var remove  = function(event, fn) {
-  if (fn)
-    emitter.removeListener(event, fn);
-  else if (event)
-   emitter.removeAllListeners(event);
-}
+var remove = function (event, fn) {
+  if (fn) emitter.removeListener(event, fn);
+  else if (event) emitter.removeAllListeners(event);
+};
 
-var unload  = function() {
-  logger.info('Unregistering hooks.')
+var unload = function () {
+  logger.info('Unregistering hooks.');
   emitter.removeAllListeners();
-}
+};
 
-emitter.on('error', function(err){
+emitter.on('error', function (err) {
+  logger.error('error on emitter error');
   // prevents 'Unspecified Error event'
-})
+});
 
-module.exports         = emitter;
+module.exports = emitter;
 module.exports.trigger = trigger;
-module.exports.remove  = remove;
-module.exports.unload  = unload;
+module.exports.remove = remove;
+module.exports.unload = unload;

--- a/lib/agent/providers/hardware/index.js
+++ b/lib/agent/providers/hardware/index.js
@@ -44,9 +44,9 @@ exp.get_firmware_info = async.memoize(function(callback){
   });
 });
 
-exp.get_storage_devices_list = function(callback){
-  callback(new Error('TODO!'))
-};
+// exp.get_storage_devices_list = function(callback){
+//   callback(new Error('TODO!'))
+// };
 
 exp.get_model_name = function(cb) {
   si.system((stdoutsi) => {

--- a/lib/agent/reports/specs.js
+++ b/lib/agent/reports/specs.js
@@ -3,8 +3,10 @@ exports.includes = [
   'firmware_info',
   'network_interfaces_list',
   'ram_module_list',
-  'storage_devices_list',
+  // 'storage_devices_list',
   'model_name',
   'vendor_name',
-  ...(process.platform == 'win32' ? ['os_edition', 'winsvc_version', 'rp_module']: [])
+  ...(process.platform == 'win32'
+    ? ['os_edition', 'winsvc_version', 'rp_module']
+    : []),
 ];

--- a/lib/agent/triggers.js
+++ b/lib/agent/triggers.js
@@ -1,117 +1,115 @@
-var fs       = require('fs'),
-    join     = require('path').join,
-    hooks    = require('./hooks'),
-    logger   = require('./common').logger.prefix('triggers');
-
-var watchers = [],
-    events_list = {},
-    running = {},
-    triggers_list;
-
+var fs = require('fs');
+var join = require('path').join;
+var hooks = require('./hooks');
+var logger = require('./common').logger.prefix('triggers');
+var watchers = [];
+var events_list = {};
+var running = {};
+var triggers_list;
 var triggers_path = join(__dirname, 'triggers');
 
-var load_trigger = function(name) {
+var load_trigger = function (name) {
   try {
     return require(join(triggers_path, name));
-  } catch(e) {
+  } catch (e) {
     hooks.trigger('error', e);
   }
-}
+};
 
-exports.map = function(cb){
+exports.map = function (cb) {
+  if (triggers_list) return cb(null, triggers_list);
 
-  if (triggers_list)
-    return cb(null, triggers_list);
-
-  fs.readdir(triggers_path, function(err, files){
+  fs.readdir(triggers_path, function (err, files) {
     if (err) return cb(err);
 
     triggers_list = {};
 
-    files.forEach(function(trigger_name) {
-      if (trigger_name.match('README'))
+    files.forEach(function (trigger_name) {
+      if (trigger_name.match('README')) {
         return;
+      }
 
       var module = load_trigger(join(triggers_path, trigger_name));
-      if (!module) return;
+      if (!module) {
+        return;
+      }
 
       triggers_list[trigger_name] = module.events;
 
-      module.events.forEach(function(evt){
+      module.events.forEach(function (evt) {
         events_list[evt] = trigger_name;
       });
-
     });
 
     cb(null, events_list);
   });
+};
 
-}
-
-exports.add = function(trigger_name, opts) {
-  start(trigger_name, opts, function(err) {
-    if (!err)
-      watchers.push(trigger_name);
+exports.add = function (trigger_name, opts) {
+  start(trigger_name, opts, function (err) {
+    if (!err) watchers.push(trigger_name);
   });
 };
 
-exports.remove = function(trigger_name) {
+exports.remove = function (trigger_name) {
   stop(trigger_name);
 };
 
-exports.watch = function(list, cb) {
-  if (!list || !list[0])
-    return cb && cb(new Error('Empty trigger list.'));
+exports.watch = function (list, cb) {
+  if (!list || !list[0]) return cb && cb(new Error('Empty trigger list.'));
 
   logger.info('Watching: ' + list.join(', '));
   list.forEach(exports.add);
   cb && cb();
-}
+};
 
-exports.unwatch = function() {
-  watchers.forEach(exports.remove)
-}
+exports.unwatch = function () {
+  watchers.forEach(exports.remove);
+};
 
-var trigger_running = function(type, trigger, name, opts, emitter) {
-  logger.info('Running: ' + name)
+var trigger_running = function (type, trigger, name, opts, emitter) {
+  logger.info('Running: ' + name);
   running[name] = trigger;
 
-  emitter.once('end', function(err, out) {
+  emitter.once('end', function (err, out) {
     if (err) hooks.trigger('error', err);
 
     logger.info(`Stopped: ${name}`);
     trigger_stopped(name);
 
-    setTimeout(function() {
+    setTimeout(function () {
       hooks.trigger(type, 'stopped', name, opts, err, out);
     }, 1000);
 
-    if (acttriggerion.events)
+    // bug!
+    if (trigger.events) {
+      logger.info('removing listeners: ' + JSON.stringify(trigger.events));
       emitter.removeAllListeners();
-  })
+    }
+  });
 
   if (!trigger.events) return;
   watch_triggers_events(trigger.events, emitter);
-}
+};
 
-var start = function(name, opts, cb){
+var start = function (name, opts, cb) {
   if (running[name]) {
     var err = new Error('Already running: ' + name);
     hooks.emit('error', err);
     return cb && cb(err);
   }
 
-  logger.info('Starting trigger: '+ name);
+  logger.info('Starting trigger: ' + name);
   var trigger = load_trigger(name);
   if (!trigger) return; // load_action will emit trigger
 
-  trigger.options = typeof opts == 'function' ? {} : opts;  //revisar para q es
+  trigger.options = typeof opts == 'function' ? {} : opts; //revisar para q es
 
-  trigger.start(opts, function(err, emitter) {
+  trigger.start(opts, function (err, emitter) {
     cb && cb(err);
 
     if (err) {
-      logger.info('Failed: ' + name + ' -> ' + err.message)
+      logger.info('Failed: ' + name + ' -> ' + err.message);
       return hooks.trigger('error', err);
     }
 
@@ -120,23 +118,21 @@ var start = function(name, opts, cb){
     if (emitter) {
       trigger_running('trigger', trigger, name, opts, emitter);
     } else {
-
       // no emitter was returned, so we have no way of knowing when
       // this action will stop. given that the command watcher needs to know
       // when an action finished in order to update the list, we'll manually
       // trigger this event after 10 seconds.
 
-      setTimeout(function() {
-        hooks.trigger(type, 'stopped', name, opts);
+      setTimeout(function () {
+        // bug!
+        hooks.trigger('action', 'stopped', name, opts);
       }, 10000);
-
     }
-  })
-
+  });
 };
 
-var stop = function(name, opts) {
-  logger.info('Stopping: ' + name);
+var stop = function (name, opts) {
+  logger.info('Stopping: ' + name + 'options: ' + JSON.stringify(opts));
   var trigger = running[name];
 
   if (!trigger) {
@@ -147,17 +143,17 @@ var stop = function(name, opts) {
   } else {
     trigger.stop();
   }
-}
+};
 
-var trigger_stopped = function(name) {
+var trigger_stopped = function (name) {
   delete running[name];
-}
+};
 
-var watch_triggers_events = function(events, emitter) {
-  events.forEach(function(event_name) {
-    emitter.on(event_name, function(data){
+var watch_triggers_events = function (events, emitter) {
+  events.forEach(function (event_name) {
+    emitter.on(event_name, function (data) {
       hooks.trigger('event', event_name, data);
       hooks.trigger(event_name, data);
-    })
-  })
-}
+    });
+  });
+};


### PR DESCRIPTION
Currently this action is removing all triggers once a new trigger is added to some device. this PR fixes this bug and includes some improvements:

- a major code refactor in the triggers.js file
- before adding or updating each trigger, check if the incoming triggers already exist in the local database to remove outdated data or add new ones.
-The last point also covers the case of trying to insert a duplicate trigger, causing an error and blocking the execution of the process.