### PR TITLE
prey_restarts.log now only works on windows, only works when is runni…

### DIFF
--- a/lib/agent/common.js
+++ b/lib/agent/common.js
@@ -23,7 +23,7 @@ common.logger = require('petit').new({
   dest: paths.config,
 });
 
-common.logger_restarts = require('petit').new({
+common.logger_restarts = os_name === 'windows' ? require('petit').new({
   level: log_level,
   file: paths.log_restarts,
   rotate: false,
@@ -31,7 +31,7 @@ common.logger_restarts = require('petit').new({
   limit: 0,
   compress: false,
   dest: paths.config,
-});
+}) : () => {};
 
 common.writeFileLoggerRestart = (textToWrite) => {
   if (!common.helpers.running_on_background() || os_name !== 'windows') return;

--- a/lib/agent/common.js
+++ b/lib/agent/common.js
@@ -1,7 +1,8 @@
 var join = require('path').join,
   common = require(join(__dirname, '..', 'common')),
   program = common.program,
-  paths = common.system.paths
+  paths = common.system.paths,
+  os_name = process.platform.replace('win32', 'windows').replace('darwin', 'mac'),
   fs = require('fs');
 
 common.helpers = require('./helpers');
@@ -10,9 +11,6 @@ var log_file =
   program.logfile || common.helpers.running_on_background()
     ? program.logfile || paths.log_file
     : null;
-
-var log_restarts = common.helpers.running_on_background() ? paths.log_restarts
-  : null;
 
 var log_level = process.env.DEBUG ? 'debug' : 'info';
 common.logger = require('petit').new({
@@ -27,7 +25,7 @@ common.logger = require('petit').new({
 
 common.logger_restarts = require('petit').new({
   level: log_level,
-  file: log_restarts,
+  file: paths.log_restarts,
   rotate: false,
   size: 200,
   limit: 0,
@@ -36,15 +34,17 @@ common.logger_restarts = require('petit').new({
 });
 
 common.writeFileLoggerRestart = (textToWrite) => {
-  fs.appendFile(log_restarts, textToWrite + '\n', ()=>{});
+  if (!common.helpers.running_on_background() || os_name !== 'windows') return;
+  fs.appendFile(paths.log_restarts, textToWrite + '\n', ()=>{});
 };
 
 common.countLinesLoggerRestarts = () => {
-  const fileBuffer = fs.readFileSync(log_restarts);
+  if (!common.helpers.running_on_background() || os_name !== 'windows') return;
+  const fileBuffer = fs.readFileSync(paths.log_restarts);
   const to_string = fileBuffer.toString();
   const split_lines = to_string.split("\n");
   if(split_lines.length > 5)
-      fs.writeFileSync(log_restarts, split_lines.slice(1, 6).join('\n'));
+      fs.writeFileSync(paths.log_restarts, split_lines.slice(1, 6).join('\n'));
 };
 
 module.exports = common;

--- a/lib/agent/index.js
+++ b/lib/agent/index.js
@@ -69,7 +69,7 @@ var run = function() {
 
   if (program.run)
     return run_from_command_line();
-  logger.info((Math.floor(new Date().getTime() / 1000)).toString());
+  
   common.writeFileLoggerRestart((Math.floor(new Date().getTime() / 1000)).toString());
   common.countLinesLoggerRestarts();
   process.title = 'prx'; // stealth camouflage FTW!


### PR DESCRIPTION
prey_restarts.log now only works on windows, only works when is running in background. This fix changes the way file is created.