### PR TITLE
fix: Remove the double api key on fresh install

### DIFF
--- a/lib/agent/plugins/control-panel/secure.js
+++ b/lib/agent/plugins/control-panel/secure.js
@@ -201,7 +201,7 @@ exports.decrypt_and_notify = function (encrypted_key, cb) {
   }
 
   if (decrypted_key) {
-    common.config.update('api_key', decrypted_key, ()=>{});
+    common.config.update('control-panel.api_key', decrypted_key, () => {});
     var key = { '-a': decrypted_key };
     account.authorize(key, function (err) {
       return cb && cb(err);


### PR DESCRIPTION
fix on the double assignment of api key on prey conf