### PR TITLE
fix: fix to api push event for permisions in macos

### DIFF
--- a/lib/agent/socket/listeners.js
+++ b/lib/agent/socket/listeners.js
@@ -12,7 +12,14 @@ const reactToCheckLocationPerms = (data) => {
     network.isWifiPermissionActive((output) => {
       permissionFile.setData('wifiLocation', stringBooleanOrEmpty(output), () => {
         // eslint-disable-next-line max-len
-        api.push.event({ wifi_location: output.toString(), native_location: data[1].result }, { json: true });
+        const dataToSend = {
+          name: 'list_permission',
+          info: {
+            wifi_location: output.toString(),
+            native_location: data[1].result,
+          },
+        };
+        api.push.event(dataToSend, { json: true });
         try {
           const callback = data[2];
           if (typeof callback === 'function') callback();


### PR DESCRIPTION
permissions in macos needed to send the name of the event in the payload to api.