### PR TITLE
fix: slower authorize command

### DIFF
--- a/lib/conf/cli.js
+++ b/lib/conf/cli.js
@@ -69,7 +69,9 @@ var start = function(cb) {
           cmd.parameters(['-a', '--api-key'], 'API Key')
           cmd.parameters(['-e', '--email'], 'Email')
           cmd.parameters(['-p', '--password'], 'Password')
-          run_if_writable(cmd, account.authorize);
+          setTimeout(() => {
+            run_if_writable(cmd, account.authorize);
+          }, 10000);
         });
     
         sub.command('verify', 'Verifies API & Device keys, optionally saving them to config.', function(cmd) {


### PR DESCRIPTION
slower authorize command to fix problems with msi install command in Windows when apikey is provided and should check apikey with backend.